### PR TITLE
Fix data path so Variety can run directly from source for development

### DIFF
--- a/variety_lib/varietyconfig.py
+++ b/variety_lib/varietyconfig.py
@@ -27,7 +27,7 @@ __all__ = [
 
 # Where your project will look for your data (for instance, images and ui
 # files). By default, this is ../data, relative your trunk layout
-__variety_data_directory__ = '/usr/share/variety/'
+__variety_data_directory__ = '../data'
 __license__ = 'GPL-3'
 __version__ = '0.6.9'
 


### PR DESCRIPTION
@jlu5 I'd like to fix this back to how it was, as now when running locally from source, Variety uses plugins, UI files, etc. from the installed version, not from the local version, which is not ok.

This is updated to the proper path in setup.py:
```
class InstallAndUpdateDataDirectory(DistUtilsExtra.auto.install_auto):
    def run(self):
        values = {'__variety_data_directory__': "'%s'" % (self.prefix + '/share/variety/'),
                  '__version__': "'%s'" % self.distribution.get_version()}
        previous_values = update_config(values)
        DistUtilsExtra.auto.install_auto.run(self)
        update_config(previous_values)
```