### PR TITLE
[WIP] a floating window widget for Variety

### DIFF
--- a/variety.desktop.in
+++ b/variety.desktop.in
@@ -14,24 +14,19 @@ Keywords=Wallpaper;Changer;Change;Download;Downloader;Variety;
 [Desktop Action Next]
 Exec=variety --next
 _Name=Next
-OnlyShowIn=Unity;
 
 [Desktop Action Previous]
 Exec=variety --previous
 _Name=Previous
-OnlyShowIn=Unity;
 
 [Desktop Action PauseResume]
 Exec=variety --toggle-pause
 _Name=Pause / Resume
-OnlyShowIn=Unity;
 
 [Desktop Action History]
 Exec=variety --history
 _Name=History
-OnlyShowIn=Unity;
 
 [Desktop Action Preferences]
 Exec=variety --preferences
 _Name=Preferences
-OnlyShowIn=Unity;

--- a/variety/FloatingWindow.py
+++ b/variety/FloatingWindow.py
@@ -8,15 +8,14 @@ gi.require_version('Gtk', '3.0')
 
 from gi.repository import Gtk, Gdk, GObject
 
-from variety import VARIETY_WINDOW
-
 class FloatingWindow(Gtk.Window):
     __gtype_name__ = "FloatingWindow"
 
-    def __init__(self):
+    def __init__(self, menu=None):
         super().__init__()
 
         self.running = True
+        self.menu = menu
 
         #self.set_decorated(False)
         self.set_accept_focus(True)
@@ -36,6 +35,7 @@ class FloatingWindow(Gtk.Window):
 
         self._eventbox = Gtk.EventBox()
         self._eventbox.set_visible(True)
+
         # Handle button press & left mouse button
         self._eventbox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON1_MOTION_MASK)
         self._eventbox.connect('motion-notify-event', self.handle_drag)
@@ -67,16 +67,16 @@ class FloatingWindow(Gtk.Window):
            We want to allow dragging in the way that the cursor is at the same position
            relative to the window when the window moves (instead of moving with the cursor
            always at the top left).
-        2) Bring up the Variety Menu when clicked.
+        2) Bring up the Variety Menu when right-clicked or double-clicked.
         """
         self._last_offset = (event.x, event.y)
 
-        # Maybe not the best practice, but I wanted this program to run in a standalone form
-        # too for testing...
-        if VARIETY_WINDOW:
-            # stub
-        else:
-            print('Not showing menu; we were started in a standalone fashion.')
+        if event.button != 1 or event.type == Gdk.EventType._2BUTTON_PRESS:
+            # This program can run as a standalone app too for testing :)
+            if self.menu:
+                self.menu.popup_at_pointer(event)
+            else:
+                print('Not showing menu; we were started in a standalone fashion.')
 
     def handle_drag(self, widget, event, data=None):
         """

--- a/variety/FloatingWindow.py
+++ b/variety/FloatingWindow.py
@@ -11,11 +11,11 @@ from gi.repository import Gtk, Gdk, GObject
 class FloatingWindow(Gtk.Window):
     __gtype_name__ = "FloatingWindow"
 
-    def __init__(self, menu=None):
+    def __init__(self, parent=None):
         super().__init__()
 
         self.running = True
-        self.menu = menu
+        self.parent = parent
 
         self.set_decorated(False)
         self.set_accept_focus(True)
@@ -73,14 +73,14 @@ class FloatingWindow(Gtk.Window):
 
         if event.button != 1 or event.type == Gdk.EventType._2BUTTON_PRESS:
             # This program can run as a standalone app too for testing :)
-            if self.menu:
-                self.menu.popup_at_pointer(event)
+            if self.parent:
+                self.parent.ind.menu.popup_at_pointer(event)
             else:
                 print('Not showing menu; we were started in a standalone fashion.')
 
     def handle_drag(self, widget, event, data=None):
         """
-        Handles drag movement when the left mouse button is clicked.
+        Handles drag movement when the left mouse button is pressed down.
         """
         if self._last_offset:
             current_x, current_y = self.get_position()

--- a/variety/FloatingWindow.py
+++ b/variety/FloatingWindow.py
@@ -17,7 +17,7 @@ class FloatingWindow(Gtk.Window):
         self.running = True
         self.menu = menu
 
-        #self.set_decorated(False)
+        self.set_decorated(False)
         self.set_accept_focus(True)
         self.set_resizable(False)
         self.set_default_size(48, 48)

--- a/variety/FloatingWindow.py
+++ b/variety/FloatingWindow.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import os
+import gi
+import cairo
+
+gi.require_version('Gtk', '3.0')
+
+from gi.repository import Gtk, Gdk, GObject
+
+from variety import VARIETY_WINDOW
+
+class FloatingWindow(Gtk.Window):
+    __gtype_name__ = "FloatingWindow"
+
+    def __init__(self):
+        super().__init__()
+
+        self.running = True
+
+        #self.set_decorated(False)
+        self.set_accept_focus(True)
+        self.set_resizable(False)
+        self.set_default_size(48, 48)
+
+        self.connect('draw', self.draw)
+
+        # Try rgba mode if compositing is on
+        screen = self.get_screen()
+        visual = screen.get_rgba_visual()
+        if visual and screen.is_composited():
+            self.set_visual(visual)
+            self.set_opacity(0.8)
+
+        self.set_app_paintable(True)
+
+        self._eventbox = Gtk.EventBox()
+        self._eventbox.set_visible(True)
+        # Handle button press & left mouse button
+        self._eventbox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON1_MOTION_MASK)
+        self._eventbox.connect('motion-notify-event', self.handle_drag)
+        self._eventbox.connect('button-press-event', self.handle_click)
+
+        self._image = Gtk.Image.new_from_icon_name("variety", Gtk.IconSize.DIALOG)
+        self._eventbox.add(self._image)
+
+        self.add(self._eventbox)
+        self.show_all()
+
+        self._last_offset = None
+
+    def draw(self, widget, context):
+        """
+        Draws the window with transparent window background.
+        """
+        # Based off https://gist.github.com/KurtJacobson/374c8cb83aee4851d39981b9c7e2c22c
+        context.set_source_rgba(0, 0, 0, 0)
+        context.set_operator(cairo.OPERATOR_SOURCE)
+        context.paint()
+        context.set_operator(cairo.OPERATOR_OVER)
+
+    def handle_click(self, widget, event, data=None):
+        """
+        Handles mouse click:
+
+        1) Find the offset from the cursor to the widget to assist with dragging.
+           We want to allow dragging in the way that the cursor is at the same position
+           relative to the window when the window moves (instead of moving with the cursor
+           always at the top left).
+        2) Bring up the Variety Menu when clicked.
+        """
+        self._last_offset = (event.x, event.y)
+
+        # Maybe not the best practice, but I wanted this program to run in a standalone form
+        # too for testing...
+        if VARIETY_WINDOW:
+            # stub
+        else:
+            print('Not showing menu; we were started in a standalone fashion.')
+
+    def handle_drag(self, widget, event, data=None):
+        """
+        Handles drag movement when the left mouse button is clicked.
+        """
+        if self._last_offset:
+            current_x, current_y = self.get_position()
+            offset_x, offset_y = self._last_offset
+            x = current_x + event.x - offset_x
+            y = current_y + event.y - offset_y
+            self.move(x, y)
+
+if __name__ == "__main__":
+    w = FloatingWindow()
+    w.show()
+    Gtk.main()

--- a/variety/FloatingWindow.py
+++ b/variety/FloatingWindow.py
@@ -17,8 +17,10 @@ class FloatingWindow(Gtk.Window):
         self.running = True
         self.parent = parent
 
-        self.set_decorated(False)
+        if os.environ.get('XDG_SESSION_TYPE') != 'wayland': # Movement tracking doesn't work on Wayland :(
+            self.set_decorated(False)
         self.set_accept_focus(True)
+        self.set_title('Variety')
         self.set_resizable(False)
         self.set_default_size(48, 48)
 

--- a/variety/FloatingWindow.py
+++ b/variety/FloatingWindow.py
@@ -37,9 +37,12 @@ class FloatingWindow(Gtk.Window):
         self._eventbox.set_visible(True)
 
         # Handle button press & left mouse button
-        self._eventbox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON1_MOTION_MASK)
+        self._eventbox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK |
+                                  Gdk.EventMask.BUTTON1_MOTION_MASK |
+                                  Gdk.EventMask.SCROLL_MASK)
         self._eventbox.connect('motion-notify-event', self.handle_drag)
         self._eventbox.connect('button-press-event', self.handle_click)
+        self._eventbox.connect('scroll-event', self.handle_scroll)
 
         self._image = Gtk.Image.new_from_icon_name("variety", Gtk.IconSize.DIALOG)
         self._eventbox.add(self._image)
@@ -88,6 +91,13 @@ class FloatingWindow(Gtk.Window):
             x = current_x + event.x - offset_x
             y = current_y + event.y - offset_y
             self.move(x, y)
+
+    def handle_scroll(self, widget, event, data=None):
+        """
+        Handles scrolling to change the wallpaper.
+        """
+        if self.parent:
+            self.parent.handle_scroll(event.direction)
 
 if __name__ == "__main__":
     w = FloatingWindow()

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -66,6 +66,7 @@ from variety.ThumbsManager import ThumbsManager
 from variety.QuotesEngine import QuotesEngine
 from variety.QuoteWriter import QuoteWriter
 from variety import indicator
+from variety.FloatingWindow import FloatingWindow
 
 DL_FOLDER_FILE = ".variety_download_folder"
 
@@ -116,6 +117,7 @@ class VarietyWindow(Gtk.Window):
         self.about = None
         self.preferences_dialog = None
         self.ind = None
+        self.floating_window = None
 
         try:
             if Gio.SettingsSchemaSource.get_default().lookup("org.gnome.desktop.background", True):
@@ -2063,6 +2065,10 @@ To set a specific wallpaper: %prog /some/local/image.jpg --next""")
             help=_("Show Preferences dialog"))
 
         parser.add_option(
+            "-F", "--floating", action="store_true", dest="floating",
+            help=_("Show mini floating window (useful on systems without indicator / tray support)"))
+
+        parser.add_option(
             "--selector", "--show-selector", action="store_true", dest="selector",
             help=_("Show manual wallpaper selector - the thumbnail bar filled with images from the active image sources"))
 
@@ -2151,6 +2157,8 @@ To set a specific wallpaper: %prog /some/local/image.jpg --next""")
                     self.show_hide_wallpaper_selector()
                 if options.preferences:
                     self.on_mnu_preferences_activate()
+                if options.floating:
+                    self.floating_window = FloatingWindow(self.ind.menu)
 
                 if options.quotes_fast_forward:
                     self.next_quote(bypass_history=True)

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1299,10 +1299,13 @@ class VarietyWindow(Gtk.Window):
         return all_images[:count]
 
     def on_indicator_scroll(self, indicator, steps, direction):
-        self.on_indicator_scroll_throttled(indicator, steps, direction)
+        self.handle_scroll(direction)
 
     @debounce(seconds=0.3)
-    def on_indicator_scroll_throttled(self, indicator, steps, direction):
+    def handle_scroll(self, direction):
+        """
+        Handles scrolling to change the wallpaper (indicator and floating widget).
+        """
         if direction == Gdk.ScrollDirection.SMOOTH:
             return
 

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -2158,7 +2158,7 @@ To set a specific wallpaper: %prog /some/local/image.jpg --next""")
                 if options.preferences:
                     self.on_mnu_preferences_activate()
                 if options.floating:
-                    self.floating_window = FloatingWindow(self.ind.menu)
+                    self.floating_window = FloatingWindow(self)
 
                 if options.quotes_fast_forward:
                     self.next_quote(bypass_history=True)

--- a/variety/__init__.py
+++ b/variety/__init__.py
@@ -152,7 +152,7 @@ def main():
     # ensure singleton
     if bus.request_name(DBUS_KEY) != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
         if not arguments:
-            arguments = ["--preferences"]
+            arguments = ["--floating"]
         safe_print(_("Variety is already running. Sending the command to the running instance."),
                    "Variety is already running. Sending the command to the running instance.")
         method = bus.get_object(DBUS_KEY, DBUS_PATH).get_dbus_method("process_command")

--- a/variety/__init__.py
+++ b/variety/__init__.py
@@ -152,7 +152,7 @@ def main():
     # ensure singleton
     if bus.request_name(DBUS_KEY) != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
         if not arguments:
-            arguments = ["--floating"]
+            arguments = ["--preferences"]
         safe_print(_("Variety is already running. Sending the command to the running instance."),
                    "Variety is already running. Sending the command to the running instance.")
         method = bus.get_object(DBUS_KEY, DBUS_PATH).get_dbus_method("process_command")


### PR DESCRIPTION
Would resolve #12 by creating a floating window for Variety (e.g. when the tray / indicator is not available).

TODO:
- [x] Draw a translucent window with the Variety icon
- [x] Disable window decorations and add custom code to handle dragging the widget
- [x] Widget should bring up Variety menu when right clicked
- [ ] Options to show / hide the widget in the Variety menu (and/or preferences?). Afterwards, only an explicit run of `variety --floating` should bring it back up.
- [ ] Option to set normal / always on top / always on bottom modes
    - We discussed this first at https://github.com/varietywalls/variety/issues/12#issuecomment-413321265, though I'm not sure always on bottom is the best default? If you already have windows open and try to bring up the Variety icon, having it be hidden might be confusing.
- [ ] Preferably make the floating widget remember its position
- [ ] Intercept iconify (show desktop) events, as in https://github.com/varietywalls/variety/issues/12#issuecomment-413678109
- [ ] Once there's proper in-app management of the widget, remove it from the taskbar
- [x] Allow changing the wallpaper when scrolling on the icon
- [ ] Maybe: allow the widget's opacity to be configured in preferences
- [x] Possibly make showing the floating icon the default instead of the preferences dialog? 
