### PR TITLE
Added documentation for extra format on 12-hour clock

### DIFF
--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -130,7 +130,7 @@ clock_date_font = "Ubuntu Condensed, 30"
 #
 # The texts can contain these symbols:
 #
-# %H - hours (24), %I - hours (12), %p - am or pm, %M - minutes,
+# %H - hours (24), %I - zero-padded hours (12), %l - hours (12), %p - am or pm, %M - minutes,
 # %A - day of week (full), %a - day of week abbreviation, %B - month name, %b - month abbreviation, %d - day of month, %Y - year.
 # The full list for these can be seen here: http://docs.python.org/library/datetime.html#strftime-strptime-behavior
 # Have in mind that Variety will not update the clock more often than once every minute, so using seconds (%S) for example is pointless


### PR DESCRIPTION
I added %l (lowercase L) which is a non-zero-padded 12-hour. Looks a lot better for 12-hour clock users.