### PR TITLE
Add Wikimedia Commons PotD as a source

### DIFF
--- a/data/config/sources.txt
+++ b/data/config/sources.txt
@@ -9,3 +9,4 @@ True|bing|Bing Photo of the Day
 True|unsplash|High-resolution photos from Unsplash.com
 False|apod|NASA's Astronomy Picture of the Day
 False|earth|World Sunlight Map - live wallpaper from Die.net
+False|wikimedia|Wikimedia Commons Picture of the Day

--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -201,6 +201,7 @@ src8 = True|unsplash|High-resolution photos from Unsplash.com
 src9 = True|apod|NASA's Astronomy Picture of the Day
 src10 = False|earth|World Sunlight Map - live wallpaper from Die.net
 src11 = True|flickr|user:www.flickr.com/photos/peter-levi/;user_id:93647178@N00;
+src12 = False|wikimedia|Wikimedia Commons Picture of the Day
 
 # Image filters to apply randomly to every wallpaper (ImageMagick is used for this)
 # Each filter is filterX = <enabled or not|filter name|arguments to pass to ImageMagick when calling convert>

--- a/variety/Options.py
+++ b/variety/Options.py
@@ -39,6 +39,7 @@ class Options:
         APOD = 8
         MEDIA_RSS = 10
         EARTH = 11
+        WIKIMEDIA = 12
         WALLHAVEN = 13
         REDDIT = 14
         BING = 15
@@ -51,6 +52,7 @@ class Options:
             DESKTOPPR: "desktoppr",
             FLICKR: "flickr",
             APOD: "apod",
+            WIKIMEDIA: "wikimedia",
             MEDIA_RSS: "mediarss",
             EARTH: "earth",
             WALLHAVEN: "wallhaven",
@@ -61,7 +63,7 @@ class Options:
 
         str_to_type = {v: k for k, v in type_to_str.items()}
 
-        dl_types = [DESKTOPPR, FLICKR, APOD, MEDIA_RSS, EARTH,
+        dl_types = [DESKTOPPR, FLICKR, APOD, WIKIMEDIA, MEDIA_RSS, EARTH,
                     WALLHAVEN, REDDIT, BING, UNSPLASH]
 
     class LightnessMode:
@@ -624,6 +626,7 @@ class Options:
             [True, Options.SourceType.UNSPLASH, "High-resolution photos from Unsplash.com"],
             [False, Options.SourceType.APOD, "NASA's Astronomy Picture of the Day"],
             [True, Options.SourceType.FLICKR, "user:www.flickr.com/photos/peter-levi/;user_id:93647178@N00;"],
+            [True, Options.SourceType.WIKIMEDIA, "Wikimedia Commons Picture of the Day"],
         ]
 
         self.filters = [

--- a/variety/Texts.py
+++ b/variety/Texts.py
@@ -39,6 +39,7 @@ SOURCES = {
     "apod": ("NASA's Astronomy Picture of the Day", _("NASA's Astronomy Picture of the Day")),
     "earth": ("World Sunlight Map - live wallpaper from Die.net",
               _("World Sunlight Map - live wallpaper from Die.net")),
+    "wikimedia": ("Wikimedia Commons Picture of the Day", _("Wikimedia Commons Picture of the Day")),
     "bing": ("Bing Photo of the Day", _("Bing Photo of the Day")),
     "unsplash": ("High-resolution photos from Unsplash.com", _("High-resolution photos from Unsplash.com")),
 }

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -56,6 +56,7 @@ from variety.BingDownloader import BingDownloader
 from variety.UnsplashDownloader import UnsplashDownloader
 from variety.DesktopprDownloader import DesktopprDownloader
 from variety.APODDownloader import APODDownloader
+from variety.WikimediaDownloader import WikimediaDownloader
 from variety.FlickrDownloader import FlickrDownloader
 from variety.MediaRssDownloader import MediaRssDownloader
 from variety.EarthDownloader import EarthDownloader, EARTH_ORIGIN_URL
@@ -520,6 +521,8 @@ class VarietyWindow(Gtk.Window):
             return APODDownloader(self)
         elif type == Options.SourceType.EARTH:
             return EarthDownloader(self)
+        elif type == Options.SourceType.WIKIMEDIA:
+            return WikimediaDownloader(self)
         elif type == Options.SourceType.FLICKR:
             return FlickrDownloader(self, location)
         elif type == Options.SourceType.WALLHAVEN:

--- a/variety/WikimediaDownloader.py
+++ b/variety/WikimediaDownloader.py
@@ -1,0 +1,64 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+### BEGIN LICENSE
+# Copyright (c) 2012, Peter Levi <peterlevi@peterlevi.com>
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+### END LICENSE
+
+import logging
+from variety import Downloader
+from variety.Util import Util
+
+logger = logging.getLogger('variety')
+
+WIKIMEDIA_ORIGIN_URL = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=potd&feedformat=rss"
+
+class WikimediaDownloader(Downloader.Downloader):
+    def __init__(self, parent):
+        super(WikimediaDownloader, self).__init__(parent, "wikimedia", "Wikimedia Commons Picture of the Day", WIKIMEDIA_ORIGIN_URL)
+        self.queue = []
+
+    def convert_to_filename(self, url):
+        return "Wikimedia"
+
+    @staticmethod
+    def fetch(url):
+        return Util.xml_soup(url)
+
+    def download_one(self):
+        logger.info(lambda: "Downloading an image from Wikimedia Commons Picture of the Day, " + self.location)
+        logger.info(lambda: "Queue size: %d" % len(self.queue))
+
+        if not self.queue:
+            self.fill_queue()
+        if not self.queue:
+            logger.info(lambda: "Wikimedia Commons queue still empty after fill request - probably nothing more to download")
+            return None
+
+        link, url = self.queue.pop()
+        logger.info(lambda: "Wikimedia URL: " + url)
+        return self.save_locally(link, url)
+
+    def fill_queue(self):
+        logger.info(lambda: "Filling Wikimedia queue from RSS")
+
+        s = self.fetch(self.location)
+        items = [x.find("description").contents[0] for x in s.findAll("item")]
+        for item in s.findAll("item"):
+            link = item.find("link").contents[0]
+            description = item.find("description").contents[0]
+            srcIndex = description.find("src=")
+            urlIndex = description.find(".jpg", srcIndex)
+            url = description[srcIndex+5:urlIndex+4].replace("/thumb", "")
+            self.queue.append([link, url])
+
+        logger.info(lambda: "Wikimedia queue populated with %d URLs" % len(self.queue))


### PR DESCRIPTION
This adds the Wikimedia Commons Picture of the Day feed as new source. It pulls from the same RSS that populates the PotD in the [Wikimedia Commons Main Page](https://commons.wikimedia.org/wiki/Main_Page)