### PR TITLE
Update test for sway wm

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -217,7 +217,7 @@ if [[ "$XDG_CURRENT_DESKTOP" == "i3"* ]] || [[ "$XDG_SESSION_DESKTOP" == "i3"* ]
     fi
 fi
 
-if [[ "$XDG_CURRENT_DESKTOP" == "sway" ]]; then
+if [[ -n $SWAYSOCK ]]; then
     swaymsg output "*" bg "$WP" fill 2> /dev/null
 fi
 


### PR DESCRIPTION
As per [swaywm#4025](https://github.com/swaywm/sway/issues/4025), `XDG_CURRENT_DESKTOP` isn't the correct way to check if the computer is running sway. This is a simple patch to switch it over to `$SWAYSOCK` which is recommended.