### PR TITLE
Fix #204: Replace usages of Gtk.threads_enter/leave with Gdk.threads_add_idle

### DIFF
--- a/data/config/ui.conf
+++ b/data/config/ui.conf
@@ -3,3 +3,6 @@ thumbs_position=bottom
 
 # Size of thumbnails stripe in pixels
 thumbs_size=120
+
+# Limit number of shown images for better performance, use "Unlimited" for no limit
+thumbs_limit=200

--- a/variety/AboutVarietyDialog.py
+++ b/variety/AboutVarietyDialog.py
@@ -16,7 +16,6 @@
 
 import logging
 
-from variety import _
 from variety_lib.AboutDialog import AboutDialog
 
 logger = logging.getLogger("variety")

--- a/variety/AbstractAddByQueryDialog.py
+++ b/variety/AbstractAddByQueryDialog.py
@@ -18,6 +18,8 @@ import threading
 
 from gi.repository import Gdk, Gtk  # pylint: disable=E0611
 
+from variety.Util import Util
+
 
 class AbstractAddByQueryDialog(Gtk.Dialog):
     def validate(self, query):
@@ -61,23 +63,21 @@ class AbstractAddByQueryDialog(Gtk.Dialog):
         self.destroy()
 
     def ok_thread(self):
-        try:
-            Gdk.threads_enter()
+        def _start_ui():
             self.ui.message.set_visible(True)
             self.ui.buttonbox.set_sensitive(False)
             self.ui.query.set_sensitive(False)
             self.ui.spinner.set_visible(True)
             self.ui.spinner.start()
             self.ui.error.set_label("")
-        finally:
-            Gdk.threads_leave()
+
+        Util.add_mainloop_task(_start_ui)
 
         query = self.ui.query.get_text().strip()
 
         final_query, invalid_msg = self.validate(query)
 
-        try:
-            Gdk.threads_enter()
+        def _stop_ui():
             if invalid_msg:
                 self.ui.buttonbox.set_sensitive(True)
                 self.ui.error.set_label(invalid_msg)
@@ -89,5 +89,5 @@ class AbstractAddByQueryDialog(Gtk.Dialog):
             else:
                 self.commit(final_query)
                 self.destroy()
-        finally:
-            Gdk.threads_leave()
+
+        Util.add_mainloop_task(_stop_ui)

--- a/variety/AddFlickrDialog.py
+++ b/variety/AddFlickrDialog.py
@@ -23,6 +23,7 @@ from gi.repository import Gdk, Gtk  # pylint: disable=E0611
 from variety import _
 from variety.FlickrDownloader import FlickrDownloader
 from variety.Options import Options
+from variety.Util import Util, on_gtk
 from variety_lib.helpers import get_builder
 
 logger = logging.getLogger("variety")
@@ -89,16 +90,13 @@ class AddFlickrDialog(Gtk.Dialog):
         """
         threading.Timer(0, self.ok_thread).start()
 
+    @on_gtk
     def show_spinner(self):
-        try:
-            Gdk.threads_enter()
-            self.ui.buttonbox.set_sensitive(False)
-            self.ui.message.set_visible(True)
-            self.ui.spinner.set_visible(True)
-            self.ui.spinner.start()
-            self.ui.error.set_label("")
-        finally:
-            Gdk.threads_leave()
+        self.ui.buttonbox.set_sensitive(False)
+        self.ui.message.set_visible(True)
+        self.ui.spinner.set_visible(True)
+        self.ui.spinner.start()
+        self.ui.error.set_label("")
 
     def ok_thread(self):
         search = ""
@@ -150,9 +148,7 @@ class AddFlickrDialog(Gtk.Dialog):
             if FlickrDownloader.count_search_results(search) <= 0:
                 self.error = _("No images found")
 
-        try:
-            Gdk.threads_enter()
-
+        def _stop_ui():
             self.ui.buttonbox.set_sensitive(True)
             self.ui.spinner.stop()
             self.ui.spinner.set_visible(False)
@@ -171,8 +167,7 @@ class AddFlickrDialog(Gtk.Dialog):
                     )
                 self.destroy()
 
-        finally:
-            Gdk.threads_leave()
+        Util.add_mainloop_task(_stop_ui)
 
     def on_btn_cancel_clicked(self, widget, data=None):
         """The user has elected cancel changes.

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -805,7 +805,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
                     Util.list_files(folders=folders, filter_func=Util.is_image, max_files=1000)
                 )
                 random.shuffle(folder_images)
-                to_show = images + folder_images[:100]
+                to_show = images + folder_images
                 if hasattr(self, "focused_image") and self.focused_image is not None:
                     try:
                         to_show.remove(self.focused_image)

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -34,7 +34,7 @@ from variety.EditFavoriteOperationsDialog import EditFavoriteOperationsDialog
 from variety.FolderChooser import FolderChooser
 from variety.Options import Options
 from variety.plugins.IQuoteSource import IQuoteSource
-from variety.Util import Util
+from variety.Util import Util, on_gtk
 from variety_lib import varietyconfig
 from variety_lib.PreferencesDialog import PreferencesDialog
 from variety_lib.varietyconfig import get_data_file
@@ -103,12 +103,10 @@ class PreferencesVarietyDialog(PreferencesDialog):
 
         self.set_status_message(msg)
 
+    @on_gtk
     def set_status_message(self, msg):
-        def _update_ui():
-            self.ui.status_message.set_visible(msg)
-            self.ui.status_message.set_markup(msg)
-
-        GObject.idle_add(_update_ui)
+        self.ui.status_message.set_visible(msg)
+        self.ui.status_message.set_markup(msg)
 
     def reload(self):
         try:
@@ -341,7 +339,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 self.loading = False
 
             def _idle_finish_loading():
-                GObject.idle_add(_finish_loading)
+                Util.add_mainloop_task(_finish_loading)
 
             timer = threading.Timer(1, _idle_finish_loading)
             timer.start()
@@ -775,7 +773,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
             if not source_rows:
                 return
 
-            self.parent.thumbs_manager.hide(gdk_thread=False, force=True)
+            self.parent.thumbs_manager.hide(force=True)
 
             images = []
             folders = []
@@ -816,16 +814,12 @@ class PreferencesVarietyDialog(PreferencesDialog):
                     to_show.insert(0, self.focused_image)
                     self.focused_image = None
                 self.parent.thumbs_manager.show(
-                    to_show,
-                    gdk_thread=False,
-                    screen=self.get_screen(),
-                    folders=folders,
-                    type=thumbs_type,
+                    to_show, screen=self.get_screen(), folders=folders, type=thumbs_type
                 )
                 if pin:
                     self.parent.thumbs_manager.pin()
                 if thumbs_type:
-                    self.parent.update_indicator(is_gtk_thread=False, auto_changed=False)
+                    self.parent.update_indicator(auto_changed=False)
 
         except Exception:
             logger.exception(lambda: "Could not create thumbs window:")
@@ -1141,7 +1135,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 chooser.destroy()
             except Exception:
                 pass
-        self.parent.thumbs_manager.hide(gdk_thread=True, force=False)
+        self.parent.thumbs_manager.hide(force=False)
 
     def on_downloaded_changed(self, widget=None):
         self.delayed_apply()
@@ -1161,6 +1155,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 important=True,
             )
 
+    @on_gtk
     def update_real_download_folder(self):
         if not Util.same_file_paths(
             self.parent.options.download_folder, self.parent.real_download_folder

--- a/variety/QuoteWriter.py
+++ b/variety/QuoteWriter.py
@@ -45,7 +45,7 @@ class QuoteWriter:
             finally:
                 done_event.set()
 
-        GObject.idle_add(go)
+        Util.add_mainloop_task(go)
         done_event.wait()
         if exception[0]:
             raise exception[0]  # pylint: disable=raising-bad-type

--- a/variety/ThumbsWindow.py
+++ b/variety/ThumbsWindow.py
@@ -162,14 +162,6 @@ class ThumbsWindow(Gtk.Window):
                     return
 
                 self.add_image(file, at_front=False)
-
-                # TODO: test and decide if still necessary:
-                # # we must yield from time to time, or GTK/cairo errors abound
-                # still_visible = self.total_width < (
-                #     self.screen_width if self.is_horizontal() else self.screen_height
-                # )
-                # time.sleep(0.02 if still_visible else 0.02)
-
                 self.image_count = i
 
         except Exception:

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -874,3 +874,11 @@ class Util:
             os.unlink(filepath)
         except Exception:
             logger.exception(lambda: "Could not delete {}, ignoring".format(filepath))
+
+
+def on_gtk(f):
+    @functools.wraps(f)
+    def wrapped(*args):
+        Util.add_mainloop_task(f, *args)
+
+    return wrapped

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1109,7 +1109,7 @@ class VarietyWindow(Gtk.Window):
     def register_downloaded_file(self, file):
         if not self.downloaded or self.downloaded[0] != file:
             self.downloaded.insert(0, file)
-            self.downloaded = self.downloaded[:100]
+            self.downloaded = self.downloaded[:1000]
             self.refresh_thumbs_downloads(file)
 
             if file.startswith(self.options.download_folder):
@@ -1603,7 +1603,7 @@ class VarietyWindow(Gtk.Window):
                 if at_front:
                     self.thumbs_manager.add_image(added_image)
                 else:
-                    self.thumbs_manager.show(self.used[:100], type="history")
+                    self.thumbs_manager.show(self.used, type="history")
                     self.thumbs_manager.pin()
 
             add_timer = threading.Timer(0, _add)
@@ -2767,7 +2767,7 @@ To set a specific wallpaper: %prog --set /some/local/image.jpg
         if self.thumbs_manager.is_showing("history"):
             self.thumbs_manager.hide(force=True)
         else:
-            self.thumbs_manager.show(self.used[:100], type="history")
+            self.thumbs_manager.show(self.used, type="history")
             self.thumbs_manager.pin()
         self.update_indicator(auto_changed=False)
 
@@ -2775,7 +2775,7 @@ To set a specific wallpaper: %prog --set /some/local/image.jpg
         if self.thumbs_manager.is_showing("downloads"):
             self.thumbs_manager.hide(force=True)
         else:
-            self.thumbs_manager.show(self.downloaded[:100], type="downloads")
+            self.thumbs_manager.show(self.downloaded, type="downloads")
             self.thumbs_manager.pin()
         self.update_indicator(auto_changed=False)
 

--- a/variety/__init__.py
+++ b/variety/__init__.py
@@ -145,7 +145,7 @@ def check_quit():
 
     global VARIETY_WINDOW
     if VARIETY_WINDOW:
-        GObject.idle_add(VARIETY_WINDOW.on_quit)
+        VARIETY_WINDOW.on_quit()
     Util.start_force_exit_thread(10)
 
 
@@ -212,11 +212,5 @@ def main():
     bus.call_on_disconnection(window.on_quit)
 
     window.start(arguments)
-
     GObject.timeout_add(2000, check_quit)
-    GObject.threads_init()
-    Gdk.threads_init()
-    Gdk.threads_enter()
-
     Gtk.main()
-    Gdk.threads_leave()


### PR DESCRIPTION
This could potentially solve some of the SIGSEGV errors we are seeing. Also enables porting to Windows (#44). In any case, threads_enter/leave was a deprecated approach to GTK threading.