### PR TITLE
[RFC] Privacy notice dialog as a stop gap measure for data collection

### DIFF
--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -120,6 +120,8 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Variety Preferences</property>
     <property name="window_position">center</property>
+    <property name="default_width">960</property>
+    <property name="default_height">200</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon">../media/variety.svg</property>
     <property name="type_hint">normal</property>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -36,25 +36,12 @@
           <object class="GtkButtonBox" id="action-area">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="margin_top">10</property>
+            <property name="margin_top">20</property>
             <property name="margin_bottom">10</property>
-            <property name="layout_style">center</property>
-            <child>
-              <object class="GtkButton" id="accept_button">
-                <property name="label" translatable="yes">Accept</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
+            <property name="layout_style">spread</property>
             <child>
               <object class="GtkButton" id="reject_button">
-                <property name="label" translatable="yes">Reject</property>
+                <property name="label" translatable="yes">Reject and Quit</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -63,6 +50,23 @@
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="accept_button">
+                <property name="label" translatable="yes">Accept and Continue</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
+                <property name="is_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -79,6 +83,10 @@
             <property name="height_request">200</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="margin_left">10</property>
+            <property name="margin_right">10</property>
+            <property name="margin_top">10</property>
+            <property name="margin_bottom">10</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="title">
@@ -112,11 +120,11 @@
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes" comments="Main text for the Privacy Notice dialog">In order to support downloads from online sources, Variety needs to periodically collect and report some information to remote servers. This includes:
 
-1. API rate limiting settings from gist.github.com &lt;a href="https://github.com/site/privacy"&gt;(privacy policy)&lt;/a&gt;
+1. Fetching API rate limiting settings defined by the Variety team from gist.github.com &lt;a href="https://github.com/site/privacy"&gt;(privacy policy)&lt;/a&gt;
 
-2. Per the &lt;a href="https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines"&gt;Unsplash API terms&lt;/a&gt;, Variety is required to track and report Unsplash images when they are first downloaded, and when they are automatically displayed / rotated on the desktop.
+2. Some image sources (e.g. &lt;a href="https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines"&gt;Unsplash&lt;/a&gt;) require us to track and report statistics of images when they are first downloaded and when they are automatically displayed / rotated on the desktop.
 
-Other web sources may collect information about your device (IP address, etc.) when Variety makes a request to download an image. In all cases, Variety does not attempt to send any personally identifiable information.</property>
+Other web sources may collect information about your device (IP address, etc.) when Variety makes a request to download an image. In all cases, Variety does not send any personally identifiable information.</property>
                 <property name="use_markup">True</property>
                 <property name="wrap">True</property>
               </object>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -2,10 +2,14 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkDialog" id="PrivacyNoticeDialog">
+  <requires lib="privacy_notice_dialog" version="1.0"/>
+  <object class="PrivacyNoticeDialog" id="PrivacyNoticeDialog">
+    <property name="name">PrivacyNoticeDialog</property>
     <property name="width_request">960</property>
     <property name="height_request">200</property>
-    <property name="can_focus">False</property>
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="has_focus">True</property>
     <property name="valign">baseline</property>
     <property name="title" translatable="yes">Variety - Privacy Notice</property>
     <property name="window_position">center</property>
@@ -17,7 +21,8 @@
       <placeholder/>
     </child>
     <child internal-child="vbox">
-      <object class="GtkBox">
+      <object class="GtkBox" id="internal-gtkbox">
+        <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
@@ -27,16 +32,18 @@
         <property name="margin_bottom">2</property>
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox">
+          <object class="GtkButtonBox" id="action-area">
+            <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_top">10</property>
             <property name="margin_bottom">10</property>
             <property name="layout_style">center</property>
             <child>
-              <object class="GtkButton" id="button1">
+              <object class="GtkButton" id="accept_button">
                 <property name="label" translatable="yes">Accept</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="action_name">accept</property>
               </object>
@@ -47,10 +54,11 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="button2">
+              <object class="GtkButton" id="reject_button">
                 <property name="label" translatable="yes">Reject</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="action_name">disable</property>
               </object>
@@ -69,7 +77,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkBox" id="main-gtkbox">
             <property name="width_request">300</property>
             <property name="height_request">200</property>
             <property name="visible">True</property>
@@ -89,7 +97,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkImage" id="image1">
+              <object class="GtkImage" id="image">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_top">10</property>
@@ -109,7 +117,7 @@
 
 1. API rate limiting settings from gist.github.com &lt;a href="https://github.com/site/privacy"&gt;(privacy policy)&lt;/a&gt;
 
-2. Per the Unsplash API terms, Variety is required to track and report Unsplash images when they are first downloaded, and when they are automatically displayed / rotated on the desktop.
+2. Per the &lt;a href="https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines"&gt;Unsplash API terms&lt;/a&gt;, Variety is required to track and report Unsplash images when they are first downloaded, and when they are automatically displayed / rotated on the desktop.
 
 Other web sources may collect information about your device (IP address, etc.) when Variety makes a request to download an image. In all cases, Variety does not attempt to send any personally identifiable information.</property>
                 <property name="use_markup">True</property>
@@ -132,8 +140,8 @@ Other web sources may collect information about your device (IP address, etc.) w
       </object>
     </child>
     <action-widgets>
-      <action-widget response="0">button1</action-widget>
-      <action-widget response="0">button2</action-widget>
+      <action-widget response="-3">accept_button</action-widget>
+      <action-widget response="-2">reject_button</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -13,7 +13,7 @@
     <property name="valign">baseline</property>
     <property name="title" translatable="yes">Variety - Privacy Notice</property>
     <property name="modal">True</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="default_width">960</property>
     <property name="default_height">200</property>
     <property name="icon_name">variety</property>
@@ -36,9 +36,10 @@
           <object class="GtkButtonBox" id="action-area">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="margin_top">20</property>
+            <property name="margin_right">15</property>
+            <property name="margin_top">15</property>
             <property name="margin_bottom">10</property>
-            <property name="layout_style">spread</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="reject_button">
                 <property name="label" translatable="yes">Reject and Quit</property>
@@ -74,6 +75,7 @@
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="padding">5</property>
+            <property name="pack_type">end</property>
             <property name="position">4</property>
           </packing>
         </child>
@@ -92,7 +94,7 @@
               <object class="GtkLabel" id="title">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;span font="14" weight="bold"&gt;Privacy Notice&lt;/span&gt;</property>
+                <property name="label" translatable="yes">&lt;span font="15" weight="bold"&gt;Privacy Notice&lt;/span&gt;</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>
@@ -118,13 +120,16 @@
               <object class="GtkLabel" id="maintext">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes" comments="Main text for the Privacy Notice dialog">In order to support downloads from online sources, Variety needs to periodically collect and report some information to remote servers. This includes:
+                <property name="margin_top">15</property>
+                <property name="label" translatable="yes" comments="Main text for the Privacy Notice dialog">Before we start, here are some things you need to be aware of and agree to:
 
-1. Fetching API rate limiting settings defined by the Variety team from gist.github.com &lt;a href="https://github.com/site/privacy"&gt;(privacy policy)&lt;/a&gt;
+&lt;b&gt;Variety is an open-source application, provided as is, without any warranties&lt;/b&gt;. By using it, you agree to the terms and conditions of the &lt;a href="https://www.gnu.org/licenses/gpl-3.0.en.html"&gt;GNU GPLv3 license&lt;/a&gt; under which it is distributed.  
 
-2. Some image sources (e.g. &lt;a href="https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines"&gt;Unsplash&lt;/a&gt;) require us to track and report statistics of images when they are first downloaded and when they are automatically displayed / rotated on the desktop.
+&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity.
 
-Other web sources may collect information about your device (IP address, etc.) when Variety makes a request to download an image. In all cases, Variety does not send any personally identifiable information.</property>
+&lt;b&gt;Variety fetches and applies rate limiting settings defined by the development team.&lt;/b&gt; This may affect the rate at which it downloads new images, but it helps ensure Variety can work regardless of how many people are running it. These settings will be downloaded from gist.github.com where we host them.
+
+&lt;b&gt;Some image sources require us to track additional information when enabled.&lt;/b&gt; For example the terms of &lt;a href="https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines"&gt;Unsplash&lt;/a&gt; require us to track and report when users download and view images from Unsplash.</property>
                 <property name="use_markup">True</property>
                 <property name="wrap">True</property>
               </object>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkDialog" id="OnlineSourcesConfirmationDialog">
+  <object class="GtkDialog" id="PrivacyNoticeDialog">
     <property name="width_request">960</property>
     <property name="height_request">200</property>
     <property name="can_focus">False</property>
@@ -29,14 +29,16 @@
         <child internal-child="action_area">
           <object class="GtkButtonBox">
             <property name="can_focus">False</property>
-            <property name="layout_style">spread</property>
+            <property name="margin_top">10</property>
+            <property name="margin_bottom">10</property>
+            <property name="layout_style">center</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label" translatable="yes">Enable Online Sources</property>
+                <property name="label" translatable="yes">Accept</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="action_name">enable</property>
+                <property name="action_name">accept</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -46,7 +48,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label" translatable="yes">Disable Online Sources</property>
+                <property name="label" translatable="yes">Reject</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -77,7 +79,7 @@
               <object class="GtkLabel" id="title">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;span font="14" weight="bold"&gt;Privacy Notice: Online Source Downloads&lt;/span&gt;</property>
+                <property name="label" translatable="yes">&lt;span font="14" weight="bold"&gt;Privacy Notice&lt;/span&gt;</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>
@@ -103,13 +105,11 @@
               <object class="GtkLabel" id="maintext">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes" comments="Main text for the Privacy Notice dialog">Variety supports automatically downloading wallpapers from online sources such as Bing, Flickr, Unsplash, and Wallhaven.
-
-In order to support these downloads, Variety needs to periodically collect and report information to remote servers. This includes:
+                <property name="label" translatable="yes" comments="Main text for the Privacy Notice dialog">In order to support downloads from online sources, Variety needs to periodically collect and report some information to remote servers. This includes:
 
 1. API rate limiting settings from gist.github.com &lt;a href="https://github.com/site/privacy"&gt;(privacy policy)&lt;/a&gt;
 
-2. Per the Unsplash API terms, Variety is required to report Unsplash images when they are displayed, and when they are automatically displayed / rotated on the desktop.
+2. Per the Unsplash API terms, Variety is required to track and report Unsplash images when they are first downloaded, and when they are automatically displayed / rotated on the desktop.
 
 Other web sources may collect information about your device (IP address, etc.) when Variety makes a request to download an image. In all cases, Variety does not attempt to send any personally identifiable information.</property>
                 <property name="use_markup">True</property>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -125,7 +125,7 @@
 
 &lt;b&gt;Variety is an open-source application, provided as is, without any warranties&lt;/b&gt;. By using it, you agree to the terms and conditions of the &lt;a href="https://www.gnu.org/licenses/gpl-3.0.en.html"&gt;GNU GPLv3 license&lt;/a&gt; under which it is distributed.  
 
-&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity.
+&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity. Note that all online image sources can be disabled. 
 
 &lt;b&gt;Variety fetches and applies rate limiting settings defined by the development team.&lt;/b&gt; This may affect the rate at which it downloads new images, but it helps ensure Variety can work regardless of how many people are running it. These settings will be downloaded from gist.github.com where we host them.
 

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkDialog" id="OnlineSourcesConfirmationDialog">
+    <property name="width_request">960</property>
+    <property name="height_request">200</property>
+    <property name="can_focus">False</property>
+    <property name="valign">baseline</property>
+    <property name="title" translatable="yes">Variety - Privacy Notice</property>
+    <property name="window_position">center</property>
+    <property name="default_width">960</property>
+    <property name="default_height">200</property>
+    <property name="icon_name">variety</property>
+    <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="margin_left">2</property>
+        <property name="margin_right">2</property>
+        <property name="margin_top">2</property>
+        <property name="margin_bottom">2</property>
+        <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">spread</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label" translatable="yes">Enable Online Sources</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">enable</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">Disable Online Sources</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">disable</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="padding">5</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="width_request">300</property>
+            <property name="height_request">200</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="title">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;span font="14" weight="bold"&gt;Privacy Notice: Online Source Downloads&lt;/span&gt;</property>
+                <property name="use_markup">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage" id="image1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="pixbuf">../media/vrty-cloud.png</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="maintext">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes" comments="Main text for the Privacy Notice dialog">Variety supports automatically downloading wallpapers from online sources such as Bing, Flickr, Unsplash, and Wallhaven.
+
+In order to support these downloads, Variety needs to periodically collect and report information to remote servers. This includes:
+
+1. API rate limiting settings from gist.github.com &lt;a href="https://github.com/site/privacy"&gt;(privacy policy)&lt;/a&gt;
+
+2. Per the Unsplash API terms, Variety is required to report Unsplash images when they are displayed, and when they are automatically displayed / rotated on the desktop.
+
+Other web sources may collect information about your device (IP address, etc.) when Variety makes a request to download an image. In all cases, Variety does not attempt to send any personally identifiable information.</property>
+                <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="padding">2</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="0">button1</action-widget>
+      <action-widget response="0">button2</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -12,6 +12,7 @@
     <property name="has_focus">True</property>
     <property name="valign">baseline</property>
     <property name="title" translatable="yes">Variety - Privacy Notice</property>
+    <property name="modal">True</property>
     <property name="window_position">center</property>
     <property name="default_width">960</property>
     <property name="default_height">200</property>
@@ -23,7 +24,7 @@
     <child internal-child="vbox">
       <object class="GtkBox" id="internal-gtkbox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can_focus">True</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
         <property name="margin_left">2</property>
@@ -34,7 +35,7 @@
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="action-area">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <property name="margin_top">10</property>
             <property name="margin_bottom">10</property>
             <property name="layout_style">center</property>
@@ -43,9 +44,7 @@
                 <property name="label" translatable="yes">Accept</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="action_name">accept</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -58,9 +57,7 @@
                 <property name="label" translatable="yes">Reject</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="action_name">disable</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -81,7 +78,7 @@
             <property name="width_request">300</property>
             <property name="height_request">200</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="title">
@@ -139,9 +136,5 @@ Other web sources may collect information about your device (IP address, etc.) w
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="-3">accept_button</action-widget>
-      <action-widget response="-2">reject_button</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -125,7 +125,7 @@
 
 &lt;b&gt;Variety is an open-source application, provided as is, without any warranties&lt;/b&gt;. By using it, you agree to the terms and conditions of the &lt;a href="https://www.gnu.org/licenses/gpl-3.0.en.html"&gt;GNU GPLv3 license&lt;/a&gt; under which it is distributed.  
 
-&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity. Note that all online image sources can be disabled. 
+&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; With default settings, Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity. Note that all online image sources can be disabled. 
 
 &lt;b&gt;Variety fetches and applies rate limiting settings defined by the development team.&lt;/b&gt; This may affect the rate at which it downloads new images, but it helps ensure Variety can work regardless of how many people are running it. These settings will be downloaded from gist.github.com where we host them.
 

--- a/data/ui/WelcomeDialog.ui
+++ b/data/ui/WelcomeDialog.ui
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <requires lib="welcome_dialog" version="1.0"/>
   <object class="WelcomeDialog" id="welcome_dialog">
-    <property name="width_request">750</property>
-    <property name="height_request">520</property>
-    <property name="can_focus">False</property>
+    <property name="width_request">960</property>
+    <property name="height_request">200</property>
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="has_focus">True</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Welcome to Variety!</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-always</property>
+    <property name="default_width">960</property>
+    <property name="default_height">200</property>
     <property name="icon">../media/variety.svg</property>
-    <property name="type_hint">normal</property>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="width_request">750</property>
@@ -37,6 +40,9 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="has_focus">True</property>
+                <property name="is_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
                 <property name="receives_default">True</property>
               </object>
               <packing>
@@ -159,8 +165,5 @@
     <action-widgets>
       <action-widget response="0">continue_button</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/data/ui/privacy_notice_dialog.xml
+++ b/data/ui/privacy_notice_dialog.xml
@@ -1,0 +1,9 @@
+<glade-catalog name="privacy_notice_dialog" domain="glade-3"
+               depends="gtk+" version="1.0">
+  <glade-widget-classes>
+    <glade-widget-class title="Privacy Notice Dialog" name="PrivacyNoticeDialog"
+                        generic-name="privacy_notice_dialog" parent="GtkDialog"
+                        icon-name="widget-gtk-dialog"/>
+  </glade-widget-classes>
+
+</glade-catalog>

--- a/variety/PrivacyNoticeDialog.py
+++ b/variety/PrivacyNoticeDialog.py
@@ -1,0 +1,51 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+### BEGIN LICENSE
+# Copyright (c) 2012, Peter Levi <peterlevi@peterlevi.com>
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+### END LICENSE
+
+from gi.repository import Gtk # pylint: disable=E0611
+
+from variety_lib.helpers import get_builder
+
+
+class PrivacyNoticeDialog(Gtk.Dialog):
+    __gtype_name__ = "PrivacyNoticeDialog"
+
+    def __new__(cls):
+        """Special static method that's automatically called by Python when
+        constructing a new instance of this class.
+
+        Returns a fully instantiated PrivacyNoticeDialog object.
+        """
+        builder = get_builder('PrivacyNoticeDialog')
+        new_object = builder.get_object('PrivacyNoticeDialog')
+        new_object.finish_initializing(builder)
+        return new_object
+
+    def finish_initializing(self, builder):
+        """Called when we're finished initializing.
+
+        finish_initalizing should be called after parsing the ui definition
+        and creating a PrivacyNoticeDialog object with it in order to
+        finish initializing the start of the new PrivacyNoticeDialog
+        instance.
+        """
+        # Get a reference to the builder and set up the signals.
+        self.builder = builder
+        self.ui = builder.get_ui(self)
+
+if __name__ == "__main__":
+    dialog = PrivacyNoticeDialog()
+    dialog.show()
+    Gtk.main()

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1,7 +1,7 @@
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
 ### BEGIN LICENSE
-# Copyright (c) 2012-2018, Peter Levi <peterlevi@peterlevi.com>
-# Copyright (c) 2017-2018, James Lu <james@overdrivenetworks.com>
+# Copyright (c) 2012-2019, Peter Levi <peterlevi@peterlevi.com>
+# Copyright (c) 2017-2019, James Lu <james@overdrivenetworks.com>
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
 # by the Free Software Foundation.
@@ -22,6 +22,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import sys
 import threading
 import time
 import urllib.parse
@@ -2239,14 +2240,15 @@ class VarietyWindow(Gtk.Window):
         dialog = PrivacyNoticeDialog()
         ok = False
 
-        def _on_accept(button):
+        def _on_accept(*args):
             dialog.destroy()
             self.dialogs.remove(dialog)
             ok = True
 
-        def _on_close(button):
+        def _on_close(*args):
             if not ok:
-                self.on_quit()
+                # At this point we shouldn't have much to clean up yet!
+                sys.exit(1)
 
         dialog.ui.accept_button.connect("clicked", _on_accept)
         dialog.ui.reject_button.connect("clicked", _on_close)

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -38,12 +38,12 @@ from variety.FlickrDownloader import FlickrDownloader
 from variety.ImageFetcher import ImageFetcher
 from variety.MediaRssDownloader import MediaRssDownloader
 from variety.Options import Options
-from variety.PrivacyNoticeDialog import PrivacyNoticeDialog
 from variety.plugins.downloaders.DefaultDownloader import SAFE_MODE_BLACKLIST
 from variety.plugins.downloaders.ImageSource import ImageSource
 from variety.plugins.downloaders.SimpleDownloader import SimpleDownloader
 from variety.plugins.IVarietyPlugin import IVarietyPlugin
 from variety.PreferencesVarietyDialog import PreferencesVarietyDialog
+from variety.PrivacyNoticeDialog import PrivacyNoticeDialog
 from variety.profile import (
     DEFAULT_PROFILE_PATH,
     get_autostart_file_path,
@@ -2238,22 +2238,19 @@ class VarietyWindow(Gtk.Window):
 
     def show_privacy_dialog(self):
         dialog = PrivacyNoticeDialog()
-        ok = False
 
         def _on_accept(*args):
             dialog.destroy()
             self.dialogs.remove(dialog)
-            ok = True
 
         def _on_close(*args):
-            if not ok:
-                # At this point we shouldn't have much to clean up yet!
-                sys.exit(1)
+            # At this point we shouldn't have much to clean up yet!
+            sys.exit(1)
 
         dialog.ui.accept_button.connect("clicked", _on_accept)
-        dialog.ui.accept_button.grab_focus()
         dialog.ui.reject_button.connect("clicked", _on_close)
         dialog.connect("delete-event", _on_close)
+        dialog.ui.accept_button.grab_focus()
         self.dialogs.append(dialog)
         dialog.run()
 

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -2251,6 +2251,7 @@ class VarietyWindow(Gtk.Window):
                 sys.exit(1)
 
         dialog.ui.accept_button.connect("clicked", _on_accept)
+        dialog.ui.accept_button.grab_focus()
         dialog.ui.reject_button.connect("clicked", _on_close)
         dialog.connect("delete-event", _on_close)
         self.dialogs.append(dialog)


### PR DESCRIPTION
In #198 we discussed the necessity and implications of collecting API throttling rates and feeding usage metrics to APIs that mandate them (e.g. Unsplash). In the absence of a complete offline mode that's likely quite invasive to implement, this PR adds a privacy policy notice to Variety's first run process.

To implement this, I've done the following:
- Refactor the welcome notice dialog to block on first start
- Insert a new privacy notice dialog right afterwards, with an Accept / Reject data collection option. Choosing Reject or closing this window will cause Variety to exit immediately.

This is what the dialog looks like so far:
![variety-privacy-notice](https://user-images.githubusercontent.com/4644601/63151845-43e12c80-bfbf-11e9-8c67-bdd0bbf36f74.png) The links in the dialog point to [GitHub's privacy policy](https://github.com/site/privacy) and the [Unsplash API docs](https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines).