### PR TITLE
Flickr API returns a slightly different URL - fix assertion

### DIFF
--- a/tests/TestFlickrDownloader.py
+++ b/tests/TestFlickrDownloader.py
@@ -64,7 +64,7 @@ class TestFlickrDownloader(unittest.TestCase):
 
     def test_get_image_url(self):
         self.assertEqual(
-            "https://live.staticflickr.com/8426/7527967456_946cc5d94b_o.jpg",
+            "https://live.staticflickr.com/8426/7527967456_41f8ae5caf_k.jpg",
             FlickrDownloader.get_image_url("https://www.flickr.com/photos/peter-levi/7527967456/"),
         )
 


### PR DESCRIPTION
Hello, I ran the unit tests as part of a fresh checkout, and this simple assertion was failing.  It appears that the Flickr Image API is returning a slightly different URL, but it's functionally the same.