### PR TITLE
Add local `site-packages` to the PYTHONPATH

### DIFF
--- a/bin/variety
+++ b/bin/variety
@@ -20,24 +20,24 @@ import sys
 
 if os.geteuid() == 0:
     print(
-        'Variety is not supposed to run as root.\n'
-        'You should NEVER run desktop apps as root, unless they are supposed to make '
-        'system-global changes and you know very well what you are doing.\n'
-        'Please run it with your normal user.\n'
-        '\n'
-        'If you are trying to run as root because Variety does not start at all with your normal '
-        'user, you may be hitting a file permission issue or a bug.\n'
-        'Here is what to do to troubleshoot:\n'
-        '\n'
+        "Variety is not supposed to run as root.\n"
+        "You should NEVER run desktop apps as root, unless they are supposed to make "
+        "system-global changes and you know very well what you are doing.\n"
+        "Please run it with your normal user.\n"
+        "\n"
+        "If you are trying to run as root because Variety does not start at all with your normal "
+        "user, you may be hitting a file permission issue or a bug.\n"
+        "Here is what to do to troubleshoot:\n"
+        "\n"
         '1. Open a terminal and run "variety -v" with your normal user.\n'
-        'Look for exceptions and hints in the log for what the problem might be.\n'
-        '\n'
-        '2. You may try to rename ~/.config/variety to ~/.config/variety_bak and try again.\n'
-        'This will have Variety start from a clean state.\n'
-        'Your old config and images will remain in variety_bak\n'
-        '\n'
-        '3. If none of these helps, open a bug in https://github.com/varietywalls/variety/issues '
-        'and follow the instructions there.'
+        "Look for exceptions and hints in the log for what the problem might be.\n"
+        "\n"
+        "2. You may try to rename ~/.config/variety to ~/.config/variety_bak and try again.\n"
+        "This will have Variety start from a clean state.\n"
+        "Your old config and images will remain in variety_bak\n"
+        "\n"
+        "3. If none of these helps, open a bug in https://github.com/varietywalls/variety/issues "
+        "and follow the instructions there."
     )
     exit(1)
 
@@ -56,6 +56,18 @@ if os.path.abspath(__file__).startswith("/opt"):
 if os.path.exists(os.path.join(PROJECT_ROOT_DIRECTORY, "variety")):
     python_path.insert(0, PROJECT_ROOT_DIRECTORY)
     sys.path.insert(0, PROJECT_ROOT_DIRECTORY)
+elif ".local" in PROJECT_ROOT_DIRECTORY:
+    local_python_site_packages = os.path.join(
+        PROJECT_ROOT_DIRECTORY,
+        "lib",
+        "python{}.{}".format(sys.version_info[0], sys.version_info[1]),
+        "site-packages",
+    )
+
+    if os.path.exists(os.path.join(local_python_site_packages, "variety")):
+        python_path.insert(0, local_python_site_packages)
+        sys.path.insert(0, local_python_site_packages)
+
 if python_path:
     os.putenv(
         "PYTHONPATH", "%s:%s" % (os.getenv("PYTHONPATH", ""), ":".join(python_path))


### PR DESCRIPTION
When launching variety, it will look for existing `site-packages`
within the `$HOME/.local` directory for the running Python version,
using the `sys.version_info` and will add it to the PYTHONPATH,
if it contains the `variety` directory, allowing the local install
to launch.

Without this commit (and no other install of variety in the system) I was getting the following error when attempting to launch it:
```
Traceback (most recent call last):
  File "/home/minkiu/.local/bin/variety", line 64, in <module>
    import variety  # isort:skip
  File "/home/minkiu/.local/bin/variety.py", line 66, in <module>
    variety.main()
AttributeError: module 'variety' has no attribute 'main'
```