### PR TITLE
Added ArtStation source.

### DIFF
--- a/variety/plugins/builtin/downloaders/ArtstationDownloader.py
+++ b/variety/plugins/builtin/downloaders/ArtstationDownloader.py
@@ -1,0 +1,51 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+### BEGIN LICENSE
+# Copyright (c) 2012, Peter Levi <peterlevi@peterlevi.com>
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+### END LICENSE
+import logging
+import random
+
+from variety.plugins.downloaders.DefaultDownloader import DefaultDownloader
+from variety.Util import Util
+
+logger = logging.getLogger("variety")
+
+
+class ArtstationDownloader(DefaultDownloader):
+    def __init__(self, source, url):
+        DefaultDownloader.__init__(self, source=source, config=url)
+
+    def fill_queue(self):
+        logger.info(lambda: "Artstation URL: " + self.config)
+
+        queue = []
+        # json_url = ArtstationDownloader.build_json_url(self.config)
+        url = self.config
+        s = Util.html_soup(url)
+        items = s.findAll("item")
+        for item in items:
+            try:
+                extra_metadata = {"sourceType": "artstation"}
+                src_url = item.find("guid").text
+                image_urls = [img["src"] for img in item.findAll("img")]
+                for image_url in image_urls:
+                    queue.append((src_url, image_url, extra_metadata))
+            except Exception:
+                logger.exception(
+                    lambda: "Could not process an "
+                    "item in the ArtStation rss result"
+                )
+
+        random.shuffle(queue)
+        return queue

--- a/variety/plugins/builtin/downloaders/ArtstationSource.py
+++ b/variety/plugins/builtin/downloaders/ArtstationSource.py
@@ -1,0 +1,108 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+### BEGIN LICENSE
+# Copyright (c) 2012, Peter Levi <peterlevi@peterlevi.com>
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+### END LICENSE
+
+import logging
+import random
+
+from variety.plugins.builtin.downloaders.ArtstationDownloader import (
+    ArtstationDownloader,
+)
+from variety.plugins.downloaders.ConfigurableImageSource import (
+    ConfigurableImageSource,
+)
+from variety.Util import _
+
+random.seed()
+
+
+logger = logging.getLogger("variety")
+
+
+class ArtstationSource(ConfigurableImageSource):
+    @classmethod
+    def get_info(cls):
+        return {
+            "name": "ArtstationSource",
+            "description": _(
+                "Configurable source for fetching images from Art Station"
+            ),
+            "author": "Denis Gordeev",
+            "version": "0.1",
+        }
+
+    def get_source_type(self):
+        return "art_station"
+
+    def get_source_name(self):
+        return "Art Station"
+
+    def get_ui_instruction(self):
+        return _(
+            "Enter the name of an artist or paste the full URL of their "
+            "artstation page with .rss extenstion or without it. \n"
+            "Example: You may specify simply 'kd428' or "
+            "<a href='https://www.artstation.com/kd428'>https://www.artstation.com/kd428</a>\n"
+            "Example: Or direct it to the RSS: "
+            "<a href='https://www.artstation.com/kd428.rss'>https://www.artstation.com/kd428.rss</a>"
+        )
+
+    def get_ui_short_instruction(self):
+        return _("URL or name of an artist: ")
+
+    def get_ui_short_description(self):
+        return _("Fetch images from a given artist")
+
+    def validate(self, query):
+        logger.info(lambda: "Validating ArtStation query " + query)
+        if query.endswith("/"):
+            query = query[:-1]
+        if "artstation.com/artwork/" in query:
+            logger.exception(lambda: "Error while validating URL, artwork url")
+            return query, _("We cannot download individual artworks.")
+        if "/" not in query:
+            query = "https://www.artstation.com/%s" % query
+        if not query.endswith(".rss"):
+            query = query + ".rss"
+        try:
+            if not query.startswith("http://") and not query.startswith(
+                "https://"
+            ):
+                query = "http://" + query
+
+            if (
+                not "//www.artstation.com" in query
+                and not "//www.artstation.com" in query
+            ):
+                return False, _(
+                    "This does not seem to be a valid ArtStation URL"
+                )
+
+            dl = ArtstationDownloader(self, query)
+            queue = dl.fill_queue()
+            return (
+                query,
+                None
+                if len(queue) > 0
+                else _("We could not find any image submissions there."),
+            )
+        except Exception:
+            logger.exception(
+                lambda: "Error while validating URL, probably no image posts for this URL"
+            )
+            return query, _("We could not find any image submissions there.")
+
+    def create_downloader(self, config):
+        return ArtstationDownloader(self, config)


### PR DESCRIPTION
This pull request adds [www.artstation.com/](artstation.com/) source.
ArtStation inherently uses .rss but as far I understand it is not MediaRSS. (see for example http://www.artstation.com/kd428.rss )
So there is a question whether to extend MediaRSS downloader or add a new one. To make it simple I added a new source.
It works only for artists' pages, not for individual works, as they have no .rss associated with them.
There were added _ArtstationDownloader.py_ and _ArtstationSource.py_ files.
In the _ArtstationSource.get_info_ I've added my name, but I don't know the project licensing and whether the name should be mine or Peter Levi (the project's author).
Other things are left unchanged.