### PR TITLE
Use iter instead of getiterator for Python 3 compatibility.

### DIFF
--- a/variety_lib/Builder.py
+++ b/variety_lib/Builder.py
@@ -91,7 +91,7 @@ class Builder(Gtk.Builder):
         tree = ElementTree()
         tree.parse(filename)
 
-        ele_widgets = tree.getiterator("object")
+        ele_widgets = tree.iter("object")
         for ele_widget in ele_widgets:
             name = ele_widget.attrib.get("id")
             if not name:
@@ -116,7 +116,7 @@ class Builder(Gtk.Builder):
             if connections:
                 self.connections.extend(connections)
 
-        ele_signals = tree.getiterator("signal")
+        ele_signals = tree.iter("signal")
         for ele_signal in ele_signals:
             self.glade_handler_dict.update({ele_signal.attrib["handler"]: None})
 


### PR DESCRIPTION
Fixes #367 