### PR TITLE
Removed 'and name.endswith(.jpg)' from old wallpaper cleanup

### DIFF
--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -2651,7 +2651,6 @@ class VarietyWindow(Gtk.Window):
                     and file != new_wallpaper
                     and file != self.post_filter_filename
                     and name.startswith(prefix)
-                    and name.endswith(".jpg")
                 ):
                     logger.debug(lambda: "Removing old wallpaper %s" % file)
                     Util.safe_unlink(file)


### PR DESCRIPTION
I followed these instructions to get variety working with KDE: https://old.reddit.com/r/kde/comments/f5s2sz/how_to_use_variety_wallpaper_changed_in_kubuntu/fo2alo5/

This worked perfectly until Variety downloaded a .png file instead of a .jpg one. Because of the "and name.endswith(.jpg)" line in VarietyWindow.py, variety was unable to delete the .png background which caused my desktop to rapidly shuffle between the newly downloaded .jpg background and the old .png one. This only got worse as more .png backgrounds were downloaded and not deleted.

By removing that line variety is now able to clean up old backgrounds of any file format and the KDE workaround is working again.