### PR TITLE
Use base64.decodebytes instead of deprecated decodestring

### DIFF
--- a/variety/Util.py
+++ b/variety/Util.py
@@ -653,7 +653,7 @@ class Util:
 
     @staticmethod
     def unxor(text, key):
-        ciphertext = base64.decodestring(text)
+        ciphertext = base64.decodebytes(text)
         return "".join(chr(x ^ ord(y)) for (x, y) in zip(ciphertext, cycle(key)))
 
     @staticmethod


### PR DESCRIPTION
Alias base64.decodestring was deprecated for years and removed in Python 3.9.

Close: #380