### PR TITLE
Connect to apod.nasa.gov using https

### DIFF
--- a/variety/plugins/builtin/downloaders/APODDownloader.py
+++ b/variety/plugins/builtin/downloaders/APODDownloader.py
@@ -27,7 +27,7 @@ random.seed()
 
 class APODDownloader(SimpleDownloader):
     DESCRIPTION = _("NASA Astro Pic of the Day")
-    ROOT_URL = "http://apod.nasa.gov/apod/"
+    ROOT_URL = "https://apod.nasa.gov/apod/"
 
     @classmethod
     def get_info(cls):


### PR DESCRIPTION
The application requests: 
```
GET /apod/image/1908/VoidMap_Tully_1288.jpg HTTP/1.1
Host: apod.nasa.gov
User-Agent: Variety Wallpaper Changer 0.8.5
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
Cache-Control: max-age=0
```

The server responds:
```
HTTP/1.0 301 Moved Permanently
Location: https://apod.nasa.gov/apod/image/1908/VoidMap_Tully_1288.jpg
Server: BigIP
Connection: Keep-Alive
Content-Length: 0
```
