### PR TITLE
Fix CPU hog

### DIFF
--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1129,7 +1129,7 @@ class VarietyWindow(Gtk.Window):
                         dl.download_one()
 
                 # give some breathing room between downloads
-                time.sleep(1)
+                time.sleep(30)
             except Exception:
                 logger.exception(lambda: "Exception in download_thread:")
 


### PR DESCRIPTION
The default  `1s` between download actions was hogging my CPU.
I suggest increasing this to `30s`.

You probably already know this but code controlling downloading should not be in the UI file "VarietyWindow.py".

Otherwise, I like it a lot - thank you! :)

