### PR TITLE
Add Dark Wallpaper Support for Gnome 42

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -167,6 +167,7 @@ fi
 
 # Gnome 3, Unity
 gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2> /dev/null
+gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2> /dev/null
 if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'" ]; then
     gsettings set org.gnome.desktop.background picture-options 'zoom'
 fi


### PR DESCRIPTION
This will ensure that variety will work regardless if you do light mode or dark mode by setting both settings the same.

This fixes #495