### PR TITLE
Fix #374, #198: Add an internet kill-switch

### DIFF
--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -7,6 +7,9 @@ change_enabled = True
 # change_interval = <interval in seconds - not less than 5>
 change_interval = 300
 
+# internet_enabled = <True or False>
+internet_enabled = True
+
 # safe_mode = <True or False>
 safe_mode = False
 

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -181,67 +181,26 @@
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="box_general">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkLabel" id="label4">
+                      <object class="GtkBox" id="box_general">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">15</property>
-                        <property name="margin_top">10</property>
-                        <property name="label" translatable="yes">General</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="autostart">
-                        <property name="label" translatable="yes">Start Variety when the computer starts</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">7</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="delayed_apply" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="box2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_right">10</property>
-                        <property name="hexpand">True</property>
+                        <property name="valign">start</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkCheckButton" id="change_enabled">
-                            <property name="label" translatable="yes">Change wallpaper every </property>
-                            <property name="use_action_appearance">False</property>
+                          <object class="GtkLabel" id="label4">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="xalign">0</property>
-                            <property name="draw_indicator">True</property>
-                            <signal name="toggled" handler="delayed_apply" swapped="no"/>
-                            <signal name="toggled" handler="on_change_enabled_toggled" swapped="no"/>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">15</property>
+                            <property name="margin_top">10</property>
+                            <property name="label" translatable="yes">General</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -250,16 +209,16 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkEntry" id="change_interval_text">
+                          <object class="GtkCheckButton" id="autostart">
+                            <property name="label" translatable="yes">Start Variety when the computer starts</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="has_tooltip">True</property>
-                            <property name="tooltip_markup" translatable="yes">Minimum interval is 5 seconds</property>
-                            <property name="tooltip_text" translatable="yes">Minimum interval is 5 seconds</property>
-                            <property name="invisible_char">•</property>
-                            <property name="width_chars">4</property>
-                            <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
-                            <signal name="focus-out-event" handler="delayed_apply" swapped="no"/>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">30</property>
+                            <property name="margin_top">7</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="delayed_apply" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -268,53 +227,152 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBox" id="change_interval_time_unit">
+                          <object class="GtkBox" id="box2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="has_tooltip">True</property>
-                            <property name="tooltip_markup" translatable="yes">Minimum interval is 5 seconds</property>
-                            <property name="tooltip_text" translatable="yes">Minimum interval is 5 seconds</property>
-                            <property name="model">liststore_change_interval</property>
-                            <property name="active">0</property>
-                            <signal name="changed" handler="delayed_apply" swapped="no"/>
+                            <property name="margin_left">30</property>
+                            <property name="margin_right">10</property>
+                            <property name="hexpand">True</property>
                             <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext1"/>
-                              <attributes>
-                                <attribute name="text">0</attribute>
-                              </attributes>
+                              <object class="GtkCheckButton" id="change_enabled">
+                                <property name="label" translatable="yes">Change wallpaper every </property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
+                                <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                                <signal name="toggled" handler="on_change_enabled_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="change_interval_text">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="has_tooltip">True</property>
+                                <property name="tooltip_markup" translatable="yes">Minimum interval is 5 seconds</property>
+                                <property name="tooltip_text" translatable="yes">Minimum interval is 5 seconds</property>
+                                <property name="invisible_char">•</property>
+                                <property name="width_chars">4</property>
+                                <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
+                                <signal name="focus-out-event" handler="delayed_apply" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="change_interval_time_unit">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="has_tooltip">True</property>
+                                <property name="tooltip_markup" translatable="yes">Minimum interval is 5 seconds</property>
+                                <property name="tooltip_text" translatable="yes">Minimum interval is 5 seconds</property>
+                                <property name="model">liststore_change_interval</property>
+                                <property name="active">0</property>
+                                <signal name="changed" handler="delayed_apply" swapped="no"/>
+                                <child>
+                                  <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">2</property>
+                              </packing>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="padding">5</property>
                             <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="change_on_start">
+                            <property name="label" translatable="yes">Change wallpaper on start</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">30</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">2</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkCheckButton" id="change_on_start">
-                        <property name="label" translatable="yes">Change wallpaper on start</property>
-                        <property name="use_action_appearance">False</property>
+                      <object class="GtkBox">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">30</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                        <property name="can_focus">False</property>
+                        <property name="margin_right">20</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel" id="label1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_top">10</property>
+                            <property name="label" translatable="yes">Use Internet Access</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="internet_enabled">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">Turning off means Variety will not download new images or quotes from online sources, or initiate other internet connections.</property>
+                            <property name="halign">end</property>
+                            <property name="margin_top">5</property>
+                            <property name="active">True</property>
+                            <signal name="state-set" handler="on_internet_enabled_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">3</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
@@ -799,14 +857,12 @@
                     <child>
                       <object class="GtkCheckButton" id="quotes_enabled">
                         <property name="label" translatable="yes">Show random wise quotes on the desktop</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">30</property>
                         <property name="margin_top">7</property>
-                        <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                         <signal name="toggled" handler="delayed_apply" swapped="no"/>
                       </object>
@@ -1633,7 +1689,6 @@
                     <child>
                       <object class="GtkCheckButton" id="clock_enabled">
                         <property name="label" translatable="yes">Show a nice big digital clock on the desktop, displaying the current time and date</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -37,38 +37,9 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="margin_right">15</property>
-            <property name="margin_top">15</property>
-            <property name="margin_bottom">10</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="reject_button">
-                <property name="label" translatable="yes">Reject and Quit</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="accept_button">
-                <property name="label" translatable="yes">Accept and Continue</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="is_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
+              <placeholder/>
             </child>
           </object>
           <packing>
@@ -88,7 +59,6 @@
             <property name="margin_left">10</property>
             <property name="margin_right">10</property>
             <property name="margin_top">10</property>
-            <property name="margin_bottom">10</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="title">
@@ -125,7 +95,7 @@
 
 &lt;b&gt;Variety is an open-source application, provided as is, without any warranties&lt;/b&gt;. By using it, you agree to the terms and conditions of the &lt;a href="https://www.gnu.org/licenses/gpl-3.0.en.html"&gt;GNU GPLv3 license&lt;/a&gt; under which it is distributed.  
 
-&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; With default settings, Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity. Note that all online image sources can be disabled. 
+&lt;b&gt;Variety is an internet-connected application.&lt;/b&gt; With default settings, Variety downloads images from the internet. Web servers it downloads from may collect information about your device, like IP address. Variety does not send any personally identifiable information. By using Variety, you accept its use of internet connectivity. &lt;b&gt;Note that all internet connectivity can be disabled.&lt;/b&gt; 
 
 &lt;b&gt;Variety fetches and applies rate limiting settings defined by the development team.&lt;/b&gt; This may affect the rate at which it downloads new images, but it helps ensure Variety can work regardless of how many people are running it. These settings will be downloaded from gist.github.com where we host them.
 
@@ -137,6 +107,94 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="height_request">0</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">40</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="label" translatable="yes">Use Internet Access:</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="internet_enabled">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="tooltip_text" translatable="yes">Enabling internet access is highly recommended. Without it, the majority of the functions Variety provides are disabled.</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="reject_button">
+                    <property name="label" translatable="yes">Reject and Quit</property>
+                    <property name="width_request">220</property>
+                    <property name="height_request">35</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="accept_button">
+                    <property name="label" translatable="yes">Accept and Continue</property>
+                    <property name="width_request">220</property>
+                    <property name="height_request">35</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="has_default">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="margin_left">15</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/data/ui/PrivacyNoticeDialog.ui
+++ b/data/ui/PrivacyNoticeDialog.ui
@@ -125,11 +125,10 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label" translatable="yes">Use Internet Access:</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
+                        <property name="margin_right">10</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Use Internet Access:&lt;/b&gt;
+&lt;i&gt;Can be changed later in Preferences&lt;/i&gt;</property>
+                        <property name="use_markup">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -141,7 +140,9 @@
                       <object class="GtkSwitch" id="internet_enabled">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Enabling internet access is highly recommended. Without it, the majority of the functions Variety provides are disabled.</property>
+                        <property name="tooltip_text" translatable="yes">Enabling internet access is highly recommended. Without it, many of the functions Variety provides are disabled. 
+
+You can change this setting later in Preferences.</property>
                         <property name="active">True</property>
                       </object>
                       <packing>

--- a/data/ui/WelcomeDialog.ui
+++ b/data/ui/WelcomeDialog.ui
@@ -17,6 +17,9 @@
     <property name="default_height">200</property>
     <property name="icon">../media/variety.svg</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="width_request">750</property>
@@ -37,10 +40,10 @@
               <object class="GtkButton" id="continue_button">
                 <property name="label" translatable="yes">Continue</property>
                 <property name="use_action_appearance">False</property>
+                <property name="width_request">150</property>
+                <property name="height_request">35</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="is_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>

--- a/variety/Options.py
+++ b/variety/Options.py
@@ -100,6 +100,11 @@ class Options:
                 pass
 
             try:
+                self.internet_enabled = config["internet_enabled"].lower() in TRUTH_VALUES
+            except Exception:
+                pass
+
+            try:
                 self.safe_mode = config["safe_mode"].lower() in TRUTH_VALUES
             except Exception:
                 pass
@@ -597,6 +602,7 @@ class Options:
         self.change_enabled = True
         self.change_on_start = False
         self.change_interval = 300
+        self.internet_enabled = True
         self.safe_mode = False
 
         self.set_wallpaper_script = os.path.join(get_profile_path(), "scripts", "set_wallpaper")
@@ -711,6 +717,7 @@ class Options:
             config["change_enabled"] = str(self.change_enabled)
             config["change_on_start"] = str(self.change_on_start)
             config["change_interval"] = str(self.change_interval)
+            config["internet_enabled"] = str(self.internet_enabled)
             config["safe_mode"] = str(self.safe_mode)
 
             config["set_wallpaper_script"] = Util.collapseuser(self.set_wallpaper_script)

--- a/variety/QuotesEngine.py
+++ b/variety/QuotesEngine.py
@@ -238,19 +238,20 @@ class QuotesEngine:
             )
 
         plugins = list(self.plugins)
+        if not self.parent.options.internet_enabled:
+            plugins = [p for p in plugins if not p["plugin"].needs_internet()]
+        if keywords or authors:
+            plugins = [p for p in plugins if p["plugin"].supports_search()]
+
         if not plugins:
             self.parent.show_notification(
-                _("No quote plugins"), _("There are no quote plugins installed")
+                _("No suitable quote plugins"),
+                _(
+                    "There are no quote plugins installed, "
+                    "enabled and applicable for the current settings"
+                ),
             )
             raise Exception("No quote plugins")
-        if keywords or authors:
-            plugins = [p for p in self.plugins if p["plugin"].supports_search()]
-            if not plugins:
-                self.parent.show_notification(
-                    _("No suitable quote plugins"),
-                    _("You have no quote plugins which support searching by keywords and authors"),
-                )
-                raise Exception("No quote plugins")
 
         error_plugins = []
         count_plugins = len(plugins)

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -317,7 +317,13 @@ class ModuleProfiler:
             )
 
 
+class InternetDisabledError(Exception):
+    pass
+
+
 class Util:
+    internet_enabled = True
+
     @staticmethod
     def sanitize_filename(filename):
         valid_chars = " ,.!-+@()_%s%s" % (string.ascii_letters, string.digits)
@@ -605,6 +611,9 @@ class Util:
 
     @staticmethod
     def request(url, data=None, stream=False, method=None, timeout=5, headers=None):
+        if not Util.internet_enabled:
+            raise InternetDisabledError("Internet access in Variety is currently disabled")
+
         if url.startswith("//"):
             url = "http:" + url
         headers = headers or {}

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1093,7 +1093,7 @@ class VarietyWindow(Gtk.Window):
                     time.sleep(30)
                     continue
 
-            time.sleep(3600)  # Update once per hour
+            time.sleep(3600 * 24)  # Update once daily
 
     def has_real_downloaders(self):
         return sum(1 for d in self.downloaders if not d.is_refresher()) > 0

--- a/variety/plugins/IQuoteSource.py
+++ b/variety/plugins/IQuoteSource.py
@@ -18,6 +18,14 @@ from .IVarietyPlugin import IVarietyPlugin
 
 
 class IQuoteSource(IVarietyPlugin):
+    def needs_internet(self):
+        """
+        Does this source fetch quotes from the internet?
+        Sources like this will not be used when Variety is configured to not access the internet.
+        :return: True or False
+        """
+        return True
+
     def supports_search(self):
         """
         False means that this plugins does not support searching by keyword or author (only get_random will

--- a/variety/plugins/builtin/quotes/FortuneSource.py
+++ b/variety/plugins/builtin/quotes/FortuneSource.py
@@ -25,7 +25,8 @@ from locale import gettext as _
 
 from variety.plugins.IQuoteSource import IQuoteSource
 
-ANSI_ESCAPE_RE = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]', flags=re.IGNORECASE)
+ANSI_ESCAPE_RE = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]", flags=re.IGNORECASE)
+
 
 class FortuneSource(IQuoteSource):
     @classmethod
@@ -40,9 +41,12 @@ class FortuneSource(IQuoteSource):
             "version": "0.1",
         }
 
+    def needs_internet(self):
+        return False
+
     def get_random(self):
         fortune = subprocess.check_output(["fortune"]).decode().strip()
-        fortune = ANSI_ESCAPE_RE.sub('', fortune)
+        fortune = ANSI_ESCAPE_RE.sub("", fortune)
         q = fortune.split("--")
         quote = q[0].strip()
         author = q[1].strip() if len(q) > 1 else None

--- a/variety/plugins/builtin/quotes/LocalFilesSource.py
+++ b/variety/plugins/builtin/quotes/LocalFilesSource.py
@@ -43,6 +43,9 @@ class LocalFilesSource(IQuoteSource):
             "version": "0.1",
         }
 
+    def needs_internet(self):
+        return False
+
     def supports_search(self):
         return True
 

--- a/variety/plugins/builtin/quotes/UrbanDictionarySource.py
+++ b/variety/plugins/builtin/quotes/UrbanDictionarySource.py
@@ -17,9 +17,8 @@
 
 from locale import gettext as _
 
-import requests
-
 from variety.plugins.IQuoteSource import IQuoteSource
+from variety.Util import Util
 
 
 class UrbanDictionarySource(IQuoteSource):
@@ -33,7 +32,7 @@ class UrbanDictionarySource(IQuoteSource):
         }
 
     def get_random(self):
-        dict_dict = requests.get("https://api.urbandictionary.com/v0/random").json()
+        dict_dict = Util.fetch_json("https://api.urbandictionary.com/v0/random")
 
         def _clean(s):
             return s.strip().replace("[", "").replace("]", "")

--- a/variety/plugins/downloaders/ConfigurableImageSource.py
+++ b/variety/plugins/downloaders/ConfigurableImageSource.py
@@ -26,7 +26,7 @@ class ConfigurableImageSource(ImageSource, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def validate(self, config):
         """
-        Given a source config, validates whether images can be fetche for this config.
+        Given a source config, validates whether images can be fetched for this config.
         As part of the validation, performs config normalization and initial lookup calls and
         returns a "final" config that will be persisted.
 

--- a/variety/plugins/downloaders/ImageSource.py
+++ b/variety/plugins/downloaders/ImageSource.py
@@ -75,6 +75,13 @@ class ImageSource(IVarietyPlugin, metaclass=abc.ABCMeta):
         source_type = self.get_source_type()
         return source_type[0].upper() + source_type[1:]
 
+    def needs_internet(self):
+        """
+        Does this configurable image source need internet in order to fetch new images?
+        :return: True or False
+        """
+        return True
+
     def on_image_set_as_wallpaper(self, img, meta):
         """
         Called when a wallpaper downloaded from this source was used as a wallpaper.


### PR DESCRIPTION
Adding a global switch to turn on or off internet access everywhere in Variety.
Also added it on the initial Privacy Notice dialog, so users can start Variety without it making any network requests.