### PR TITLE
Fix #89: Options to select fit size / wallpaper mode. Image-dependent smart fit.

### DIFF
--- a/data/config/filters.txt
+++ b/data/config/filters.txt
@@ -4,7 +4,8 @@
 
 False|Keep original|
 False|Grayscale|-type Grayscale
-False|Heavy blur|-blur 120x40
+False|Heavy blur|-scale 20% -blur 0x10 -resize 500%
+False|Soft blur|-scale 20% -blur 0x2 -resize 500%
 False|Oil painting|-paint 8
 False|Pointilism|-spread 10 -noise 3
 False|Pixellate|-scale 3% -scale 3333%

--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -227,8 +227,8 @@ src11 = True|flickr|user:www.flickr.com/photos/peter-levi/;user_id:93647178@N00;
 [filters]
 filter1 = False|Keep original|
 filter2 = False|Grayscale|-type Grayscale
-filter3 = False|Heavy blur|-blur 120x40
-filter4 = False|Soft blur|-blur 20x7
+filter3 = False|Heavy blur|-scale 20% -blur 0x10 -resize 500%
+filter4 = False|Soft blur|-scale 20% -blur 0x2 -resize 500%
 filter5 = False|Oil painting|-paint 8
 filter6 = False|Pointilism|-spread 10 -noise 3
 filter7 = False|Pixellate|-scale 3% -scale 3333%

--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -56,7 +56,9 @@ favorites_operations = Downloaded:Copy;Fetched:Move;Others:Copy
 # wallpaper_auto_rotate = <True or False>
 wallpaper_auto_rotate = False
 
-# wallpaper_display_mode = <"os" | "zoom" | "fill-with-black" | "fill-with-blur" | "smart-with-black" | "smart-with-blur">
+# wallpaper_display_mode = <"os" |
+# "smart" | "zoom" | "fill-with-black" | "fill-with-blur" |
+# "gnome-zoom" | "gnome-centered" | "gnome-scaled" | "gnome-stretched" | "gnome-spanned", "gnome-wallpaper">
 wallpaper_display_mode = "os"
 
 # fetch_folder = <some folder> - when not specified, the default is ~/.config/variety/Fetched

--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -53,6 +53,12 @@ favorites_folder = ~/.config/variety/Favorites
 # Move to Favorites is only shown when the user has write permissions over the file, otherwise we fallback to Copy
 favorites_operations = Downloaded:Copy;Fetched:Move;Others:Copy
 
+# wallpaper_auto_rotate = <True or False>
+wallpaper_auto_rotate = False
+
+# wallpaper_display_mode = <"os" | "zoom" | "fill-with-black" | "fill-with-blur" | "smart-with-black" | "smart-with-blur">
+wallpaper_display_mode = "os"
+
 # fetch_folder = <some folder> - when not specified, the default is ~/.config/variety/Fetched
 fetched_folder = ~/.config/variety/Fetched
 

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -171,22 +171,31 @@ fi
 # Gnome 3, Unity
 gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2> /dev/null
 gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ] || [ "$4" == "zoom" ]; then
+if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ]; then
     gsettings set org.gnome.desktop.background picture-options 'zoom'
+fi
+if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
+    gsettings set org.gnome.desktop.background picture-options "$4"
 fi
 
 # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch
 gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ] || [ "$4" == "zoom" ]; then
+if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
     gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
+fi
+if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
+    gsettings set org.gnome.desktop.screensaver picture-options "$4"
 fi
 
 
 # Deepin
 if [ "$(gsettings list-schemas | grep -c com.deepin.wrap.gnome.desktop.background)" -ge 1 ]; then
     gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "file://$WP"
-    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ] || [ "$4" == "zoom" ]; then
+    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ]; then
         gsettings set com.deepin.wrap.gnome.desktop.background picture-options 'zoom'
+    fi
+    if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
+        gsettings set com.deepin.wrap.gnome.desktop.background picture-options "$4"
     fi
 fi
 
@@ -249,11 +258,20 @@ fi
 
 # MATE after 1.6
 gsettings set org.mate.background picture-filename "$WP" 2> /dev/null
+if [ "$(gsettings get org.mate.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
+	gsettings set org.mate.desktop.background picture-options 'zoom'
+fi
+if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
+  gsettings set org.mate.desktop.background picture-options "$4"
+fi
 
 # Cinnamon after 2.0
 gsettings set org.cinnamon.desktop.background picture-uri "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.cinnamon.desktop.background picture-options 2>/dev/null)" == "'none'" ] || [ "$4" == "zoom" ]; then
+if [ "$(gsettings get org.cinnamon.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
 	gsettings set org.cinnamon.desktop.background picture-options 'zoom'
+fi
+if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
+  gsettings set org.cinnamon.desktop.background picture-options "$4"
 fi
 
 # Awesome Window Manager

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -171,31 +171,30 @@ fi
 # Gnome 3, Unity
 gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2> /dev/null
 gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ]; then
-    gsettings set org.gnome.desktop.background picture-options 'zoom'
-fi
 if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
     gsettings set org.gnome.desktop.background picture-options "$4"
+fi
+if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ]; then
+    gsettings set org.gnome.desktop.background picture-options 'zoom'
 fi
 
 # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch
 gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
-    gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
-fi
 if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
     gsettings set org.gnome.desktop.screensaver picture-options "$4"
 fi
-
+if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
+    gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
+fi
 
 # Deepin
 if [ "$(gsettings list-schemas | grep -c com.deepin.wrap.gnome.desktop.background)" -ge 1 ]; then
     gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "file://$WP"
-    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ]; then
-        gsettings set com.deepin.wrap.gnome.desktop.background picture-options 'zoom'
-    fi
     if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
         gsettings set com.deepin.wrap.gnome.desktop.background picture-options "$4"
+    fi
+    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ]; then
+        gsettings set com.deepin.wrap.gnome.desktop.background picture-options 'zoom'
     fi
 fi
 
@@ -227,8 +226,10 @@ SIMPLE_WMS=("bspwm" "dwm" "herbstluftwm" "i3" "i3-with-shmlog" "jwm" "LeftWM" "o
 if [[ " ${SIMPLE_WMS[*]} " = *" $XDG_CURRENT_DESKTOP "* || " ${SIMPLE_WMS[*]} " = *" $XDG_SESSION_DESKTOP "* ||
       " ${SIMPLE_WMS[*]} " = *" $DESKTOP_SESSION "* ]]; then
 	if command -v "feh" >/dev/null 2>&1; then
+	      # TODO: This should take the scaling parameter $4 into account and use other options than --bg-fill
         feh --bg-fill "$WP" 2> /dev/null
     elif command -v "nitrogen" >/dev/null 2>&1; then
+	      # TODO: This should take the scaling parameter $4 into account and use other options than --set-zoom-fill
         nitrogen --set-zoom-fill --save "$WP" 2> /dev/null
     fi
 fi
@@ -283,10 +284,5 @@ if [[ "$XDG_SESSION_DESKTOP $DESKTOP_STARTUP_ID $DESKTOP_SESSION $XDG_CURRENT_DE
 fi
 
 # =====================================================================================
-
-# OPTIONAL: Show a notification on automatic wallpaper change.
-# Display the original filename in the notification, but actually apply the post-effects image.
-# name=$(echo "$3" | sed 's/\//\n/g'| tail -n 1)
-# if [ "$2" == "auto" ]; then notify-send --icon "$WP" "Wallpaper changed" "$name" ; fi
 
 exit 0

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -18,6 +18,9 @@
 #
 # $3: The third passed parameter is the absolute path to the original wallpaper image (before effects, clock, etc.)
 #
+# $4: Fourth parameter comes from the display mode setting: "os" means that set_wallpaper should try to
+# leave the OS setting unchanged. "zoom" means to try to fill the screen fully with the provided image.
+#
 # EXAMPLE:
 # echo "$1" # /home/username/.config/variety/wallpaper/wallpaper-clock-fac0eef772f9b03bd9c0f82a79d72506.jpg
 # echo "$2" # auto
@@ -168,13 +171,13 @@ fi
 # Gnome 3, Unity
 gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2> /dev/null
 gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'" ]; then
+if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ] || [ "$4" == "zoom" ]; then
     gsettings set org.gnome.desktop.background picture-options 'zoom'
 fi
 
 # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch
 gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
+if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ] || [ "$4" == "zoom" ]; then
     gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
 fi
 
@@ -182,7 +185,7 @@ fi
 # Deepin
 if [ "$(gsettings list-schemas | grep -c com.deepin.wrap.gnome.desktop.background)" -ge 1 ]; then
     gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "file://$WP"
-    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ]; then
+    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ] || [ "$4" == "zoom" ]; then
         gsettings set com.deepin.wrap.gnome.desktop.background picture-options 'zoom'
     fi
 fi
@@ -249,7 +252,7 @@ gsettings set org.mate.background picture-filename "$WP" 2> /dev/null
 
 # Cinnamon after 2.0
 gsettings set org.cinnamon.desktop.background picture-uri "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.cinnamon.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
+if [ "$(gsettings get org.cinnamon.desktop.background picture-options 2>/dev/null)" == "'none'" ] || [ "$4" == "zoom" ]; then
 	gsettings set org.cinnamon.desktop.background picture-options 'zoom'
 fi
 

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -20,6 +20,9 @@
 #
 # $4: Fourth parameter comes from the display mode setting: "os" means that set_wallpaper should try to
 # leave the OS setting unchanged. "zoom" means to try to fill the screen fully with the provided image.
+# Other parameters that could be passed are the scaling modes used by GNOME:
+# "centered", "scaled", "stretched", "zoom", "spanned", "wallpaper"
+# TODO: Ideally all sections below for different DEs would take this setting into account
 #
 # EXAMPLE:
 # echo "$1" # /home/username/.config/variety/wallpaper/wallpaper-clock-fac0eef772f9b03bd9c0f82a79d72506.jpg

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -81,26 +81,6 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkSizeGroup" id="sizegroup_quotes_appearance">
-    <widgets>
-      <widget name="label50"/>
-      <widget name="label54"/>
-      <widget name="label51"/>
-      <widget name="label53"/>
-      <widget name="label44"/>
-      <widget name="label57"/>
-      <widget name="label61"/>
-      <widget name="label47"/>
-      <widget name="label29"/>
-    </widgets>
-  </object>
-  <object class="GtkSizeGroup" id="sizegroup_quotes_placement_labels">
-    <widgets>
-      <widget name="label55"/>
-      <widget name="label59"/>
-      <widget name="label62"/>
-    </widgets>
-  </object>
   <object class="GtkAdjustment" id="slideshow_fade_adjustment">
     <property name="upper">1</property>
     <property name="step_increment">0.050000000000000003</property>
@@ -865,7 +845,9 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_top">7</property>
-                        <property name="label" translatable="yes">Experimental: Some options may not work well in all window managers or multi-monitor configurations</property>
+                        <property name="label" translatable="yes">Experimental: Some options may not work well in all desktop environments or multi-monitor configurations.</property>
+                        <property name="justify">fill</property>
+                        <property name="wrap">True</property>
                         <attributes>
                           <attribute name="style" value="italic"/>
                         </attributes>
@@ -4432,6 +4414,26 @@ Peter Levi</property>
     <widgets>
       <widget name="change_interval_text"/>
       <widget name="quotes_change_interval_text"/>
+    </widgets>
+  </object>
+  <object class="GtkSizeGroup" id="sizegroup_quotes_appearance">
+    <widgets>
+      <widget name="label50"/>
+      <widget name="label54"/>
+      <widget name="label51"/>
+      <widget name="label53"/>
+      <widget name="label44"/>
+      <widget name="label57"/>
+      <widget name="label61"/>
+      <widget name="label47"/>
+      <widget name="label29"/>
+    </widgets>
+  </object>
+  <object class="GtkSizeGroup" id="sizegroup_quotes_placement_labels">
+    <widgets>
+      <widget name="label55"/>
+      <widget name="label59"/>
+      <widget name="label62"/>
     </widgets>
   </object>
   <object class="GtkSizeGroup" id="sizegroup_slideshow_combos">

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -80,6 +80,26 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkSizeGroup" id="sizegroup_quotes_appearance">
+    <widgets>
+      <widget name="label50"/>
+      <widget name="label54"/>
+      <widget name="label51"/>
+      <widget name="label53"/>
+      <widget name="label44"/>
+      <widget name="label57"/>
+      <widget name="label61"/>
+      <widget name="label47"/>
+      <widget name="label29"/>
+    </widgets>
+  </object>
+  <object class="GtkSizeGroup" id="sizegroup_quotes_placement_labels">
+    <widgets>
+      <widget name="label55"/>
+      <widget name="label59"/>
+      <widget name="label62"/>
+    </widgets>
+  </object>
   <object class="GtkAdjustment" id="slideshow_fade_adjustment">
     <property name="upper">1</property>
     <property name="step_increment">0.050000000000000003</property>
@@ -746,7 +766,7 @@
                     <property name="halign">start</property>
                     <property name="margin_left">15</property>
                     <property name="margin_top">10</property>
-                    <property name="label" translatable="yes">Filters</property>
+                    <property name="label" translatable="yes">Effects</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -771,7 +791,7 @@
                         <property name="margin_left">20</property>
                         <property name="margin_right">20</property>
                         <property name="margin_top">7</property>
-                        <property name="label" translatable="yes">Randomly apply these filters to the displayed wallpapers (thanks to the wonderful ImageMagick):</property>
+                        <property name="label" translatable="yes">Randomly apply these effects to the displayed wallpapers (thanks to the wonderful ImageMagick):</property>
                         <property name="justify">fill</property>
                         <property name="wrap">True</property>
                       </object>
@@ -789,6 +809,7 @@
                         <property name="margin_right">20</property>
                         <property name="margin_top">10</property>
                         <property name="orientation">vertical</property>
+                        <property name="row_spacing">5</property>
                         <property name="column_spacing">20</property>
                         <child>
                           <placeholder/>
@@ -832,1019 +853,10 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="box22">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkLabel" id="label37">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">15</property>
-                        <property name="margin_top">15</property>
-                        <property name="label" translatable="yes">Quotes</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="quotes_enabled">
-                        <property name="label" translatable="yes">Show random wise quotes on the desktop</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">7</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="delayed_apply" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkExpander" id="expander1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">5</property>
-                        <child>
-                          <object class="GtkBox" id="box26">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkBox" id="box28">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_top">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label54">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Text color: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkColorButton" id="quotes_text_color">
-                                    <property name="use_action_appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <signal name="color-set" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label50">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="label" translatable="yes">Text font: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkFontButton" id="quotes_font">
-                                    <property name="use_action_appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="font">Sans 12</property>
-                                    <property name="preview_text">Neither success, nor failure, are final.</property>
-                                    <property name="show_preview_entry">False</property>
-                                    <signal name="font-set" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box29">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">30</property>
-                                <child>
-                                  <object class="GtkLabel" id="label51">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Backdrop color: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkColorButton" id="quotes_bg_color">
-                                    <property name="use_action_appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <signal name="color-set" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label53">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="label" translatable="yes">Backdrop opacity: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label64">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="label" translatable="yes"> Transparent</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkScale" id="quotes_bg_opacity">
-                                    <property name="width_request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="margin_left">5</property>
-                                    <property name="adjustment">quotes_bg_opacity_adjustment</property>
-                                    <property name="fill_level">100</property>
-                                    <property name="round_digits">0</property>
-                                    <property name="draw_value">False</property>
-                                    <signal name="value-changed" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">4</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label65">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Opaque</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">10</property>
-                                    <property name="position">5</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="quotes_text_shadow">
-                                <property name="label" translatable="yes">Draw a text shadow</property>
-                                <property name="use_action_appearance">False</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_top">5</property>
-                                <property name="xalign">0</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="delayed_apply" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label41">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Appearance</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkExpander" id="expander5">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">7</property>
-                        <child>
-                          <object class="GtkBox" id="box31">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_left">30</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkBox" id="box32">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_top">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label44">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Quotes area width: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label55">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="label" translatable="yes">Narrow </property>
-                                    <property name="xalign">1</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkScale" id="quotes_width">
-                                    <property name="width_request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="margin_left">5</property>
-                                    <property name="adjustment">quotes_width_adjustment</property>
-                                    <property name="fill_level">100</property>
-                                    <property name="round_digits">0</property>
-                                    <property name="draw_value">False</property>
-                                    <signal name="value-changed" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label56">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Wide</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">10</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box33">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkLabel" id="label57">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Horizontal position: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label59">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="label" translatable="yes">Left </property>
-                                    <property name="xalign">1</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkScale" id="quotes_hpos">
-                                    <property name="width_request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="margin_left">5</property>
-                                    <property name="adjustment">quotes_hpos_adjustment</property>
-                                    <property name="fill_level">100</property>
-                                    <property name="round_digits">0</property>
-                                    <property name="draw_value">False</property>
-                                    <signal name="value-changed" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label60">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Right</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">10</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box34">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkLabel" id="label61">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Vertical position: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label62">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_left">10</property>
-                                    <property name="label" translatable="yes">Top </property>
-                                    <property name="xalign">1</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkScale" id="quotes_vpos">
-                                    <property name="width_request">100</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="margin_left">5</property>
-                                    <property name="adjustment">quotes_vpos_adjustment</property>
-                                    <property name="fill_level">100</property>
-                                    <property name="round_digits">0</property>
-                                    <property name="draw_value">False</property>
-                                    <signal name="value-changed" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label63">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Bottom</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">10</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label58">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Placement</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkExpander" id="expander2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">7</property>
-                        <child>
-                          <object class="GtkBox" id="box23">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkBox" id="box27">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="hexpand">True</property>
-                                <child>
-                                  <object class="GtkLabel" id="label48">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin_left">30</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">10</property>
-                                    <property name="label" translatable="yes">Show quotes from these sources: </property>
-                                    <property name="use_markup">True</property>
-                                    <property name="justify">fill</property>
-                                    <property name="wrap">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkGrid" id="quotes_sources_grid">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_right">20</property>
-                                <property name="margin_top">5</property>
-                                <property name="orientation">vertical</property>
-                                <property name="column_spacing">20</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label49">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="halign">start</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_right">20</property>
-                                <property name="margin_top">3</property>
-                                <property name="margin_bottom">10</property>
-                                <property name="hexpand">True</property>
-                                <property name="label" translatable="yes">&lt;small&gt;&lt;a href='http://peterlevi.com/variety/wiki/Plugins'&gt;More plugins&lt;/a&gt;&lt;/small&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="justify">fill</property>
-                                <property name="wrap">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label38">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_right">20</property>
-                                <property name="margin_top">10</property>
-                                <property name="label" translatable="yes">Show only these tags and authors. Leave empty to show random quotes.</property>
-                                <property name="justify">fill</property>
-                                <property name="wrap">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkGrid" id="grid1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_right">30</property>
-                                <property name="margin_top">10</property>
-                                <property name="column_spacing">5</property>
-                                <child>
-                                  <object class="GtkEntry" id="quotes_authors">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="invisible_char">•</property>
-                                    <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkEntry" id="quotes_tags">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="invisible_char">•</property>
-                                    <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label45">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Tags: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label46">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Example: funny, inspirational</property>
-                                    <property name="use_markup">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label40">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Example: Albert Einstein, Voltaire</property>
-                                    <property name="use_markup">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label39">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Authors: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label42">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Sources and filtering</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkExpander" id="expander3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">7</property>
-                        <child>
-                          <object class="GtkBox" id="box30">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_left">30</property>
-                            <property name="margin_right">10</property>
-                            <property name="margin_top">5</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkCheckButton" id="quotes_change_enabled">
-                                <property name="label" translatable="yes">Change quote every </property>
-                                <property name="use_action_appearance">False</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="xalign">0</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="delayed_apply" swapped="no"/>
-                                <signal name="toggled" handler="on_quotes_change_enabled_toggled" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="quotes_change_interval_text">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Minimum interval is 10 seconds</property>
-                                <property name="tooltip_text" translatable="yes">Minimum interval is 10 seconds</property>
-                                <property name="invisible_char">•</property>
-                                <property name="width_chars">4</property>
-                                <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
-                                <signal name="focus-out-event" handler="delayed_apply" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="quotes_change_interval_time_unit">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Minimum interval is 10 seconds</property>
-                                <property name="tooltip_text" translatable="yes">Minimum interval is 10 seconds</property>
-                                <property name="model">liststore_change_interval</property>
-                                <property name="active">0</property>
-                                <signal name="changed" handler="delayed_apply" swapped="no"/>
-                                <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext5"/>
-                                  <attributes>
-                                    <attribute name="text">0</attribute>
-                                  </attributes>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label43">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Regular change</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">5</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
+                  <placeholder/>
                 </child>
                 <child>
-                  <object class="GtkBox" id="box25">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkLabel" id="label28">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">15</property>
-                        <property name="margin_top">15</property>
-                        <property name="label" translatable="yes">Clock</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="clock_enabled">
-                        <property name="label" translatable="yes">Show a nice big digital clock on the desktop, displaying the current time and date</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">To configure the clock's appearance edit the clock_filter property in Variety's settings file (~/.config/variety/variety.conf). Use the comments in ~/.config/variety/variety_latest_default.conf as a guide.</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">7</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="delayed_apply" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkExpander" id="expander4">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_left">30</property>
-                        <property name="margin_top">5</property>
-                        <child>
-                          <object class="GtkBox" id="box21">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkBox" id="box24">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_top">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label47">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Clock font: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkFontButton" id="clock_font">
-                                    <property name="use_action_appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="font">Sans 12</property>
-                                    <property name="preview_text">Neither success, nor failure, are final.</property>
-                                    <property name="show_preview_entry">False</property>
-                                    <signal name="font-set" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box11">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">30</property>
-                                <child>
-                                  <object class="GtkLabel" id="label29">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Date font: </property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkFontButton" id="clock_date_font">
-                                    <property name="use_action_appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="font">Sans 12</property>
-                                    <property name="preview_text">Neither success, nor failure, are final.</property>
-                                    <property name="show_preview_entry">False</property>
-                                    <signal name="font-set" handler="delayed_apply" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label11">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin_left">30</property>
-                                <property name="margin_right">30</property>
-                                <property name="margin_top">7</property>
-                                <property name="label" translatable="yes">These don't work? &lt;a href="https://answers.launchpad.net/variety/+faq/2138"&gt;Read here&lt;/a&gt;. How to further configure the clock? &lt;a href="http://peterlevi.com/variety/2012/11/configuring-the-clock/"&gt;Read here&lt;/a&gt;.</property>
-                                <property name="use_markup">True</property>
-                                <property name="justify">fill</property>
-                                <property name="wrap">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label52">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Appearance</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -1859,6 +871,1032 @@
               </object>
               <packing>
                 <property name="position">1</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="quotes_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">15</property>
+                <property name="margin_right">15</property>
+                <property name="margin_top">10</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="label37">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Quotes</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">15</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkCheckButton" id="quotes_enabled">
+                        <property name="label" translatable="yes">Show random wise quotes on the desktop</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_top">7</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box30">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">5</property>
+                        <property name="hexpand">True</property>
+                        <child>
+                          <object class="GtkCheckButton" id="quotes_change_enabled">
+                            <property name="label" translatable="yes">Change quote every </property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                            <signal name="toggled" handler="on_quotes_change_enabled_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="quotes_change_interval_text">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="has_tooltip">True</property>
+                            <property name="tooltip_markup" translatable="yes">Minimum interval is 10 seconds</property>
+                            <property name="tooltip_text" translatable="yes">Minimum interval is 10 seconds</property>
+                            <property name="invisible_char">•</property>
+                            <property name="width_chars">4</property>
+                            <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
+                            <signal name="focus-out-event" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="quotes_change_interval_time_unit">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="has_tooltip">True</property>
+                            <property name="tooltip_markup" translatable="yes">Minimum interval is 10 seconds</property>
+                            <property name="tooltip_text" translatable="yes">Minimum interval is 10 seconds</property>
+                            <property name="model">liststore_change_interval</property>
+                            <property name="active">0</property>
+                            <signal name="changed" handler="delayed_apply" swapped="no"/>
+                            <child>
+                              <object class="GtkCellRendererText" id="cellrenderertext5"/>
+                              <attributes>
+                                <attribute name="text">0</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label41">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_top">15</property>
+                    <property name="label" translatable="yes">Appearance</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box26">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">15</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkBox" id="box28">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">5</property>
+                        <child>
+                          <object class="GtkLabel" id="label54">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Text color: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="quotes_text_color">
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="color-set" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label50">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">20</property>
+                            <property name="label" translatable="yes">Text font: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFontButton" id="quotes_font">
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="font">Sans 12</property>
+                            <property name="preview_text">Neither success, nor failure, are final.</property>
+                            <property name="show_preview_entry">False</property>
+                            <signal name="font-set" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="quotes_text_shadow">
+                            <property name="label" translatable="yes">Draw a text shadow</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">40</property>
+                            <property name="margin_top">5</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box29">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="label51">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Backdrop color: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="quotes_bg_color">
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="color-set" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label53">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_left">20</property>
+                            <property name="label" translatable="yes">Backdrop opacity: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label64">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes"> Transparent</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="quotes_bg_opacity">
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="margin_left">10</property>
+                            <property name="adjustment">quotes_bg_opacity_adjustment</property>
+                            <property name="fill_level">100</property>
+                            <property name="draw_value">False</property>
+                            <signal name="value-changed" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label65">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Opaque</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">10</property>
+                            <property name="position">5</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label43">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_top">15</property>
+                    <property name="label" translatable="yes">Placement</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box31">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">15</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkBox" id="box33">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">7</property>
+                        <child>
+                          <object class="GtkLabel" id="label57">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Horizontal position: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label59">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Left </property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="quotes_hpos">
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="margin_left">10</property>
+                            <property name="adjustment">quotes_hpos_adjustment</property>
+                            <property name="fill_level">100</property>
+                            <property name="draw_value">False</property>
+                            <signal name="value-changed" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label60">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Right</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">10</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box32">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_left">60</property>
+                            <child>
+                              <object class="GtkLabel" id="label44">
+                                <property name="width_request">-1</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Quotes area width: </property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label55">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Narrow </property>
+                                <property name="xalign">1</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkScale" id="quotes_width">
+                                <property name="width_request">100</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="adjustment">quotes_width_adjustment</property>
+                                <property name="fill_level">100</property>
+                                <property name="draw_value">False</property>
+                                <signal name="value-changed" handler="delayed_apply" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label56">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Wide</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">10</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box34">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">7</property>
+                        <child>
+                          <object class="GtkLabel" id="label61">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Vertical position: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label62">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Top </property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="quotes_vpos">
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="margin_left">10</property>
+                            <property name="adjustment">quotes_vpos_adjustment</property>
+                            <property name="fill_level">100</property>
+                            <property name="draw_value">False</property>
+                            <signal name="value-changed" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label63">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Bottom</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">10</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label42">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_top">15</property>
+                    <property name="label" translatable="yes">Sources and filtering</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box23">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">15</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkBox" id="box27">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <child>
+                          <object class="GtkLabel" id="label48">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_top">10</property>
+                            <property name="label" translatable="yes">Show quotes from these sources: </property>
+                            <property name="use_markup">True</property>
+                            <property name="justify">fill</property>
+                            <property name="wrap">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkGrid" id="quotes_sources_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">7</property>
+                        <property name="orientation">vertical</property>
+                        <property name="row_spacing">5</property>
+                        <property name="column_spacing">20</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label49">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">start</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">&lt;small&gt;&lt;a href='http://peterlevi.com/variety/wiki/Plugins'&gt;More plugins&lt;/a&gt;&lt;/small&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="justify">fill</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label38">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_top">10</property>
+                        <property name="label" translatable="yes">Show only these tags and authors. Leave empty to show random quotes.</property>
+                        <property name="justify">fill</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkGrid" id="grid1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">10</property>
+                        <property name="column_spacing">5</property>
+                        <child>
+                          <object class="GtkEntry" id="quotes_authors">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="invisible_char">•</property>
+                            <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="quotes_tags">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="invisible_char">•</property>
+                            <signal name="changed" handler="delayed_apply_slow" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label45">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Tags: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label46">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Example: funny, inspirational</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label40">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Example: Albert Einstein, Voltaire</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label39">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Authors: </property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">8</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="quotes_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Quotes</property>
+              </object>
+              <packing>
+                <property name="position">2</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="clock_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">15</property>
+                <property name="margin_right">15</property>
+                <property name="margin_top">10</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="label28">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Clock</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="clock_enabled">
+                    <property name="label" translatable="yes">Show a nice big digital clock on the desktop, displaying the current time and date</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">To configure the clock's appearance edit the clock_filter property in Variety's settings file (~/.config/variety/variety.conf). Use the comments in ~/.config/variety/variety_latest_default.conf as a guide.</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">15</property>
+                    <property name="margin_top">7</property>
+                    <property name="xalign">0</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel" id="label52">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_top">20</property>
+                        <property name="label" translatable="yes">Appearance</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box21">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">15</property>
+                        <property name="margin_right">15</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox" id="box24">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_top">5</property>
+                            <child>
+                              <object class="GtkLabel" id="label47">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Clock font: </property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFontButton" id="clock_font">
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="font">Sans 12</property>
+                                <property name="preview_text">Neither success, nor failure, are final.</property>
+                                <property name="show_preview_entry">False</property>
+                                <signal name="font-set" handler="delayed_apply" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box11">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label29">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Date font: </property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFontButton" id="clock_date_font">
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="font">Sans 12</property>
+                                <property name="preview_text">Neither success, nor failure, are final.</property>
+                                <property name="show_preview_entry">False</property>
+                                <signal name="font-set" handler="delayed_apply" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label11">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">start</property>
+                            <property name="margin_top">7</property>
+                            <property name="label" translatable="yes">These don't work? &lt;a href="https://answers.launchpad.net/variety/+faq/2138"&gt;Read here&lt;/a&gt;. How to further configure the clock? &lt;a href="http://peterlevi.com/variety/2012/11/configuring-the-clock/"&gt;Read here&lt;/a&gt;.</property>
+                            <property name="use_markup">True</property>
+                            <property name="justify">fill</property>
+                            <property name="wrap">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="clock_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Clock</property>
+              </object>
+              <packing>
+                <property name="position">3</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -2515,7 +2553,7 @@
                 </child>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child type="tab">
@@ -2525,7 +2563,7 @@
                 <property name="label" translatable="yes">Slideshow</property>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">4</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -2773,17 +2811,17 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 </child>
               </object>
               <packing>
-                <property name="position">3</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="fetch_tab_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Manual downloading</property>
+                <property name="label" translatable="yes">Downloading</property>
               </object>
               <packing>
-                <property name="position">3</property>
+                <property name="position">5</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -3149,17 +3187,17 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 </child>
               </object>
               <packing>
-                <property name="position">4</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="filtering_tab_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Color and size</property>
+                <property name="label" translatable="yes">Filtering</property>
               </object>
               <packing>
-                <property name="position">4</property>
+                <property name="position">6</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -3645,7 +3683,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 </child>
               </object>
               <packing>
-                <property name="position">5</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child type="tab">
@@ -3655,7 +3693,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 <property name="label" translatable="yes">Customize</property>
               </object>
               <packing>
-                <property name="position">5</property>
+                <property name="position">7</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -3855,7 +3893,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 </child>
               </object>
               <packing>
-                <property name="position">6</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child type="tab">
@@ -3865,7 +3903,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 <property name="label" translatable="yes">Tips</property>
               </object>
               <packing>
-                <property name="position">6</property>
+                <property name="position">8</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -4065,7 +4103,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 </child>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">9</property>
               </packing>
             </child>
             <child type="tab">
@@ -4075,7 +4113,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                 <property name="label" translatable="yes">Changelog</property>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">9</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -4191,7 +4229,7 @@ Peter Levi</property>
                 </child>
               </object>
               <packing>
-                <property name="position">8</property>
+                <property name="position">10</property>
               </packing>
             </child>
             <child type="tab">
@@ -4201,7 +4239,7 @@ Peter Levi</property>
                 <property name="label" translatable="yes">Donate</property>
               </object>
               <packing>
-                <property name="position">8</property>
+                <property name="position">10</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -4281,26 +4319,6 @@ Peter Levi</property>
     <widgets>
       <widget name="change_interval_text"/>
       <widget name="quotes_change_interval_text"/>
-    </widgets>
-  </object>
-  <object class="GtkSizeGroup" id="sizegroup_quotes_appearance">
-    <widgets>
-      <widget name="label50"/>
-      <widget name="label54"/>
-      <widget name="label51"/>
-      <widget name="label53"/>
-      <widget name="label44"/>
-      <widget name="label57"/>
-      <widget name="label61"/>
-      <widget name="label47"/>
-      <widget name="label29"/>
-    </widgets>
-  </object>
-  <object class="GtkSizeGroup" id="sizegroup_quotes_placement_labels">
-    <widgets>
-      <widget name="label55"/>
-      <widget name="label59"/>
-      <widget name="label62"/>
     </widgets>
   </object>
   <object class="GtkSizeGroup" id="sizegroup_slideshow_combos">

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -793,6 +793,7 @@
                         <property name="receives_default">False</property>
                         <property name="margin_top">7</property>
                         <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="delayed_apply" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -840,12 +841,14 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel">
+                      <object class="GtkLabel" id="wallpaper_mode_description">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_top">7</property>
-                        <property name="label" translatable="yes">Experimental: Some options may not work well in all window managers or multi-monitor configurations</property>
+                        <property name="label" translatable="yes">Description goes here </property>
+                        <property name="justify">fill</property>
+                        <property name="wrap">True</property>
                         <attributes>
                           <attribute name="style" value="italic"/>
                         </attributes>
@@ -857,14 +860,12 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="wallpaper_mode_description">
+                      <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_top">7</property>
-                        <property name="label" translatable="yes">Description goes here </property>
-                        <property name="justify">fill</property>
-                        <property name="wrap">True</property>
+                        <property name="label" translatable="yes">Experimental: Some options may not work well in all window managers or multi-monitor configurations</property>
                         <attributes>
                           <attribute name="style" value="italic"/>
                         </attributes>

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -768,7 +768,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_top">10</property>
-                    <property name="label" translatable="yes">Alignment</property>
+                    <property name="label" translatable="yes">Alignment and scaling</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -12,6 +12,7 @@
       <mime-type>image/*</mime-type>
     </mime-types>
   </object>
+  <object class="GtkListStore" id="liststore1"/>
   <object class="GtkListStore" id="liststore_change_interval">
     <columns>
       <!-- column-name time_period -->
@@ -757,16 +758,17 @@
               <object class="GtkBox" id="effects_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_left">15</property>
+                <property name="margin_right">15</property>
                 <property name="margin_bottom">10</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel" id="label14">
+                  <object class="GtkLabel" id="label58">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin_left">15</property>
                     <property name="margin_top">10</property>
-                    <property name="label" translatable="yes">Effects</property>
+                    <property name="label" translatable="yes">Alignment</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -778,18 +780,136 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">20</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkCheckButton" id="wallpaper_auto_rotate">
+                        <property name="label" translatable="yes">Auto-rotate the image according to EXIF data</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="margin_top">7</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">7</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Display mode</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="wallpaper_display_mode">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_left">10</property>
+                            <property name="active_id">os</property>
+                            <signal name="changed" handler="delayed_apply" swapped="no"/>
+                            <signal name="changed" handler="on_wallpaper_display_mode_changed" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_top">7</property>
+                        <property name="label" translatable="yes">Experimental: Some options may not work well in all window managers or multi-monitor configurations</property>
+                        <attributes>
+                          <attribute name="style" value="italic"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="wallpaper_mode_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_top">7</property>
+                        <property name="label" translatable="yes">Description goes here </property>
+                        <property name="justify">fill</property>
+                        <property name="wrap">True</property>
+                        <attributes>
+                          <attribute name="style" value="italic"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label14">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_top">20</property>
+                    <property name="label" translatable="yes">Effects</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox" id="box6">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">10</property>
+                    <property name="margin_left">20</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin_left">20</property>
-                        <property name="margin_right">20</property>
                         <property name="margin_top">7</property>
                         <property name="label" translatable="yes">Randomly apply these effects to the displayed wallpapers (thanks to the wonderful ImageMagick):</property>
                         <property name="justify">fill</property>
@@ -805,8 +925,6 @@
                       <object class="GtkGrid" id="filters_grid">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">20</property>
-                        <property name="margin_right">20</property>
                         <property name="margin_top">10</property>
                         <property name="orientation">vertical</property>
                         <property name="row_spacing">5</property>
@@ -849,14 +967,8 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">3</property>
                   </packing>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -867,7 +979,7 @@
               <object class="GtkLabel" id="effects_tab_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Effects</property>
+                <property name="label" translatable="yes">Wallpaper</property>
               </object>
               <packing>
                 <property name="position">1</property>

--- a/variety/Options.py
+++ b/variety/Options.py
@@ -572,7 +572,12 @@ class Options:
                         continue
                     try:
                         s = Options.parse_filter(line.strip())
-                        if not s[1].lower() in [f[1].lower() for f in self.filters]:
+                        for f in self.filters:
+                            if f[1].lower() == s[1].lower():
+                                f[2] = s[2]
+                                break
+                        else:
+                            # not found at all in filters, append it
                             self.filters.append(s)
                     except Exception:
                         logger.exception(lambda: "Cannot parse filter in filters.txt: " + line)

--- a/variety/Options.py
+++ b/variety/Options.py
@@ -162,6 +162,16 @@ class Options:
                 pass
 
             try:
+                self.wallpaper_auto_rotate = config["wallpaper_auto_rotate"].lower() in TRUTH_VALUES
+            except Exception:
+                pass
+
+            try:
+                self.wallpaper_display_mode = str(config["wallpaper_display_mode"]).strip()
+            except Exception:
+                pass
+
+            try:
                 self.fetched_folder = os.path.expanduser(config["fetched_folder"])
             except Exception:
                 pass
@@ -628,6 +638,9 @@ class Options:
             ["Others", "Copy"],
         ]
 
+        self.wallpaper_auto_rotate = True
+        self.wallpaper_display_mode = "os"
+
         self.fetched_folder = os.path.join(get_profile_path(), "Fetched")
         self.clipboard_enabled = False
         self.clipboard_use_whitelist = True
@@ -743,6 +756,9 @@ class Options:
             config["favorites_operations"] = ";".join(
                 ":".join(x) for x in self.favorites_operations
             )
+
+            config["wallpaper_auto_rotate"] = str(self.wallpaper_auto_rotate)
+            config["wallpaper_display_mode"] = str(self.wallpaper_display_mode)
 
             config["fetched_folder"] = Util.collapseuser(self.fetched_folder)
             config["clipboard_enabled"] = str(self.clipboard_enabled)

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -29,6 +29,7 @@ from variety import Texts
 from variety.AddConfigurableDialog import AddConfigurableDialog
 from variety.AddFlickrDialog import AddFlickrDialog
 from variety.AddWallhavenDialog import AddWallhavenDialog
+from variety.display_modes import DISPLAY_MODES
 from variety.EditFavoriteOperationsDialog import EditFavoriteOperationsDialog
 from variety.FolderChooser import FolderChooser
 from variety.Options import Options
@@ -139,6 +140,11 @@ class PreferencesVarietyDialog(PreferencesDialog):
             self.ui.internet_enabled.set_active(self.options.internet_enabled)
 
             self.fav_chooser.set_folder(os.path.expanduser(self.options.favorites_folder))
+            self.ui.wallpaper_auto_rotate.set_active(self.options.wallpaper_auto_rotate)
+            self.ui.wallpaper_display_mode.remove_all()
+            for mode in DISPLAY_MODES:
+                self.ui.wallpaper_display_mode.append(mode["id"], mode["title"])
+            self.ui.wallpaper_display_mode.set_active_id(self.options.wallpaper_display_mode)
 
             self.fetched_chooser.set_folder(os.path.expanduser(self.options.fetched_folder))
             self.ui.clipboard_enabled.set_active(self.options.clipboard_enabled)
@@ -350,6 +356,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
             self.on_quotes_change_enabled_toggled()
             self.on_icon_changed()
             self.on_favorites_operations_changed()
+            self.on_wallpaper_display_mode_changed()
             self.update_clipboard_state()
             self.update_status_message()
         finally:
@@ -905,6 +912,15 @@ class PreferencesVarietyDialog(PreferencesDialog):
         dialog.set_source(source)
         self.show_dialog(dialog)
 
+    def on_wallpaper_display_mode_changed(self, *args):
+        modes = [
+            m for m in DISPLAY_MODES if m["id"] == self.ui.wallpaper_display_mode.get_active_id()
+        ]
+        if modes:
+            self.ui.wallpaper_mode_description.set_text(modes[0].get("description", ""))
+        else:
+            self.ui.wallpaper_mode_description.set_text("")
+
     def show_dialog(self, dialog):
         self.dialog = dialog
         self.dialog.parent = self
@@ -973,6 +989,9 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 self.options.sources.append(self.model_row_to_source(r))
             for s in self.unsupported_sources:
                 self.options.sources.append(s)
+
+            self.options.wallpaper_auto_rotate = self.ui.wallpaper_auto_rotate.get_active()
+            self.options.wallpaper_display_mode = self.ui.wallpaper_display_mode.get_active_id()
 
             if os.access(self.fetched_chooser.get_folder(), os.W_OK):
                 self.options.fetched_folder = self.fetched_chooser.get_folder()

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -48,6 +48,9 @@ from variety_lib.varietyconfig import get_data_file
 random.seed()
 logger = logging.getLogger("variety")
 
+SLIDESHOW_PAGE_INDEX = 4
+DONATE_PAGE_INDEX = 10
+
 
 class PreferencesVarietyDialog(PreferencesDialog):
     __gtype_name__ = "PreferencesVarietyDialog"
@@ -80,7 +83,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
         )
 
         if not Util.check_variety_slideshow_present():
-            self.ui.notebook.remove_page(2)
+            self.ui.notebook.remove_page(SLIDESHOW_PAGE_INDEX)
 
         profile_suffix = (
             "" if is_default_profile() else _(" (Profile: {})").format(get_profile_short_name())

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -29,7 +29,6 @@ from variety import Texts
 from variety.AddConfigurableDialog import AddConfigurableDialog
 from variety.AddFlickrDialog import AddFlickrDialog
 from variety.AddWallhavenDialog import AddWallhavenDialog
-from variety.display_modes import DISPLAY_MODES
 from variety.EditFavoriteOperationsDialog import EditFavoriteOperationsDialog
 from variety.FolderChooser import FolderChooser
 from variety.Options import Options
@@ -142,8 +141,8 @@ class PreferencesVarietyDialog(PreferencesDialog):
             self.fav_chooser.set_folder(os.path.expanduser(self.options.favorites_folder))
             self.ui.wallpaper_auto_rotate.set_active(self.options.wallpaper_auto_rotate)
             self.ui.wallpaper_display_mode.remove_all()
-            for mode in DISPLAY_MODES:
-                self.ui.wallpaper_display_mode.append(mode["id"], mode["title"])
+            for mode in self.parent.get_display_modes():
+                self.ui.wallpaper_display_mode.append(mode.id, mode.title)
             self.ui.wallpaper_display_mode.set_active_id(self.options.wallpaper_display_mode)
 
             self.fetched_chooser.set_folder(os.path.expanduser(self.options.fetched_folder))
@@ -914,10 +913,12 @@ class PreferencesVarietyDialog(PreferencesDialog):
 
     def on_wallpaper_display_mode_changed(self, *args):
         modes = [
-            m for m in DISPLAY_MODES if m["id"] == self.ui.wallpaper_display_mode.get_active_id()
+            m
+            for m in self.parent.get_display_modes()
+            if m.id == self.ui.wallpaper_display_mode.get_active_id()
         ]
         if modes:
-            self.ui.wallpaper_mode_description.set_text(modes[0].get("description", ""))
+            self.ui.wallpaper_mode_description.set_text(modes[0].description)
         else:
             self.ui.wallpaper_mode_description.set_text("")
 

--- a/variety/QuoteWriter.py
+++ b/variety/QuoteWriter.py
@@ -84,8 +84,7 @@ class QuoteWriter:
         iw = surface.get_width()
         ih = surface.get_height()
 
-        sw = Gdk.Screen.get_default().get_width()
-        sh = Gdk.Screen.get_default().get_height()
+        sw, sh = Util.get_primary_display_size(hidpi_scaled=True)
         trimw, trimh = Util.compute_trimmed_offsets((iw, ih), (sw, sh))
 
         width = max(

--- a/variety/Texts.py
+++ b/variety/Texts.py
@@ -64,7 +64,7 @@ TIPS = [
         'Variety can be controlled from the command line and you can use this to define keyboard shortcuts for the operations you use most often. Run "variety --help" to see all available commands.'
     ),
     _(
-        'You can drop image links or files on the launcher icon to download them and use them as wallpapers. For quicker downloading from a specific site, you can also use clipboard monitoring (see "Manual downloading" tab).'
+        'You can drop image links or files on the launcher icon to download them and use them as wallpapers. For quicker downloading from a specific site, you can also use clipboard monitoring (see "Downloading" tab).'
     ),
     _(
         "Applying a heavy blurring filter is a great way to get abstract-looking and unobtrusive, yet colorful wallpapers, similar in spirit to the default one in Ubuntu."

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -710,10 +710,7 @@ class Util:
     def get_scaled_size(image):
         """Computes the size to which the image is scaled to fit the screen: original_size * scale_ratio = scaled_size"""
         iw, ih = Util.get_size(image)
-        screen_w, screen_h = (
-            Gdk.Screen.get_default().get_width(),
-            Gdk.Screen.get_default().get_height(),
-        )
+        screen_w, screen_h = Util.get_primary_display_size()
         screen_ratio = float(screen_w) / screen_h
         if (
             screen_ratio > float(iw) / ih
@@ -721,22 +718,6 @@ class Util:
             return screen_w, int(round(ih * float(screen_w) / iw))
         else:  # image is "wider" than the screen ratio - need to offset horizontally
             return int(round(iw * float(screen_h) / ih)), screen_h
-
-    @staticmethod
-    def get_scale_to_screen_ratio(image):
-        """Computes the ratio by which the image is scaled to fit the screen: original_size * scale_ratio = scaled_size"""
-        iw, ih = Util.get_size(image)
-        screen_w, screen_h = (
-            Gdk.Screen.get_default().get_width(),
-            Gdk.Screen.get_default().get_height(),
-        )
-        screen_ratio = float(screen_w) / screen_h
-        if (
-            screen_ratio > float(iw) / ih
-        ):  # image is "taller" than the screen ratio - need to offset vertically
-            return int(float(screen_w) / iw)
-        else:  # image is "wider" than the screen ratio - need to offset horizontally
-            return int(float(screen_h) / ih)
 
     @staticmethod
     def gtk_to_fcmatch_font(gtk_font_name):

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -596,6 +596,14 @@ class Util:
             return image_width, image_height
 
     @staticmethod
+    def get_primary_display_size(hidpi_scaled=True):
+        display = Gdk.Display.get_default()
+        monitor = display.get_primary_monitor()
+        geometry = monitor.get_geometry()
+        scale = monitor.get_scale_factor() if hidpi_scaled else 1.0
+        return int(geometry.width * scale), int(geometry.height * scale)
+
+    @staticmethod
     def find_unique_name(filename):
         index = filename.rfind(".")
         if index < 0:

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -604,6 +604,11 @@ class Util:
         return int(geometry.width * scale), int(geometry.height * scale)
 
     @staticmethod
+    def get_multimonitor_display_size():
+        screen = Gdk.Screen.get_default()
+        return screen.get_width(), screen.get_height()
+
+    @staticmethod
     def find_unique_name(filename):
         index = filename.rfind(".")
         if index < 0:
@@ -909,10 +914,6 @@ class Util:
                 if not os.path.islink(fp):
                     total_size += os.path.getsize(fp)
         return total_size
-
-    @staticmethod
-    def get_screen_width():
-        return Gdk.Screen.get_default().get_width()
 
 
 def on_gtk(f):

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -42,7 +42,7 @@ from variety.plugins.downloaders.DefaultDownloader import SAFE_MODE_BLACKLIST
 from variety.plugins.downloaders.ImageSource import ImageSource
 from variety.plugins.downloaders.SimpleDownloader import SimpleDownloader
 from variety.plugins.IVarietyPlugin import IVarietyPlugin
-from variety.PreferencesVarietyDialog import PreferencesVarietyDialog
+from variety.PreferencesVarietyDialog import DONATE_PAGE_INDEX, PreferencesVarietyDialog
 from variety.PrivacyNoticeDialog import PrivacyNoticeDialog
 from variety.profile import (
     DEFAULT_PROFILE_PATH,
@@ -63,6 +63,7 @@ from variety_lib import varietyconfig
 
 # fmt: off
 import gi  # isort:skip
+
 gi.require_version("Notify", "0.7")
 from gi.repository import Gdk, GdkPixbuf, Gio, GObject, Gtk, Notify  # isort:skip
 Notify.init("Variety")
@@ -200,7 +201,7 @@ class VarietyWindow(Gtk.Window):
             self.about = None
 
     def on_mnu_donate_activate(self, widget, data=None):
-        self.preferences_dialog.ui.notebook.set_current_page(8)
+        self.preferences_dialog.ui.notebook.set_current_page(DONATE_PAGE_INDEX)
         self.on_mnu_preferences_activate()
         webbrowser.open_new_tab(DONATE_URL)
 
@@ -1028,7 +1029,7 @@ class VarietyWindow(Gtk.Window):
         ):
             logger.warning(
                 lambda: "Too few images found: %d out of %d. "
-                "Please check the settings in 'Color and size'." % (len(found), len(images))
+                "Please check the settings in 'Filtering'." % (len(found), len(images))
             )
             if not hasattr(self, "filters_warning_shown") or not self.filters_warning_shown:
                 self.filters_warning_shown = True
@@ -1036,7 +1037,7 @@ class VarietyWindow(Gtk.Window):
                     _("Filtering too strict?"),
                     _(
                         "Variety is finding too few images that match your image filtering "
-                        'criteria. Please check if the settings in "Color and size" are correct.'
+                        'criteria. Please check if the settings in "Filtering" are correct.'
                     ),
                 )
 

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1247,7 +1247,13 @@ class VarietyWindow(Gtk.Window):
         if not filename:
             logger.warning(lambda: "set_wp_throttled: No wallpaper to set")
             return
-        self.do_set_wp(filename, refresh_level)
+
+        self.thumbs_manager.mark_active(file=filename, position=self.position)
+
+        def _do_set_wp():
+            self.do_set_wp(filename, refresh_level)
+
+        threading.Timer(0, _do_set_wp).start()
 
     def build_imagemagick_filter_cmd(self, filename, target_file):
         if not self.filters:
@@ -1520,7 +1526,6 @@ class VarietyWindow(Gtk.Window):
         logger.info(lambda: "Calling do_set_wp with %s, time: %s" % (filename, time.time()))
         with self.do_set_wp_lock:
             try:
-                self.thumbs_manager.mark_active(file=filename, position=self.position)
                 if not os.access(filename, os.R_OK):
                     logger.info(
                         lambda: "Missing file or bad permissions, will not use it: " + filename

--- a/variety/display_modes.py
+++ b/variety/display_modes.py
@@ -1,16 +1,16 @@
 from variety.Util import Util, _
 
 
-def _os():
+def _os(filename):
     return "os", None
 
 
-def _zoom():
+def _zoom(filename):
     w, h = Util.get_primary_display_size()
     return "zoom", "-scale %dx%d^ " % (w, h)
 
 
-def _fill_with_black():
+def _fill_with_black(filename):
     w, h = Util.get_primary_display_size()
     return (
         "zoom",
@@ -18,7 +18,7 @@ def _fill_with_black():
     )
 
 
-def _fill_with_blur():
+def _fill_with_blur(filename):
     w, h = Util.get_primary_display_size()
     return (
         "zoom",

--- a/variety/display_modes.py
+++ b/variety/display_modes.py
@@ -2,13 +2,35 @@ from variety.Util import Util, _
 
 
 def _os():
-    return None, None
+    return "os", None
+
+
+def _zoom():
+    w, h = Util.get_primary_display_size()
+    return "zoom", "-scale %dx%d^ " % (w, h)
+
+
+def _fill_with_black():
+    w, h = Util.get_primary_display_size()
+    return (
+        "zoom",
+        "-resize %dx%d\> -size %dx%d xc:black +swap -gravity center -composite" % (w, h, w, h),
+    )
+
+
+def _fill_with_blur():
+    w, h = Util.get_primary_display_size()
+    return (
+        "zoom",
+        "-resize %dx%d^ -gravity center -extent %dx%d -blur 0x10 -clone 0 -resize %dx%d -size %dx%d -gravity center -composite"
+        % (w, h, w, h, w, h, w, h),
+    )
 
 
 DISPLAY_MODES = [
     {
         "id": "os",
-        "title": _("Controlled by OS settings, not by Variety"),
+        "title": _("Controlled by OS settings, not by Variety. Fastest option."),
         "description": _(
             "Display mode is controlled by your OS Appearance settings and by what is "
             "specified in set_wallpaper script for your desktop environment. "
@@ -23,7 +45,7 @@ DISPLAY_MODES = [
             "Some parts of the image will be cut out if its resolution is different "
             "from the screen's. "
         ),
-        "fn": _os,
+        "fn": _zoom,
     },
     {
         "id": "fill-with-black",
@@ -32,16 +54,16 @@ DISPLAY_MODES = [
             "Image is zoomed in or out so that it fully fits within your primary screen. "
             "The rest of the screen is filled with black. "
         ),
-        "fn": _os,
+        "fn": _fill_with_black,
     },
     {
         "id": "fill-with-blur",
-        "title": _("Fill with blur"),
+        "title": _("Fill with blur. Slow."),
         "description": _(
             "Image is zoomed in or out so that it fully fits within your primary screen. "
             "The rest of the screen is a filled with blurred version of the image. "
         ),
-        "fn": _os,
+        "fn": _fill_with_blur,
     },
     {
         "id": "smart-with-black",
@@ -51,16 +73,16 @@ DISPLAY_MODES = [
             "Images that are close to the screen proportions use 'Zoom'. "
             "Those that are vastly different use 'Fill with black'. "
         ),
-        "fn": _os,
+        "fn": _fill_with_black,  # TODO implement
     },
     {
         "id": "smart-with-blur",
-        "title": _("Pick dynamically between Zoom and Fill with blur"),
+        "title": _("Pick dynamically between Zoom and Fill with blur. Slow."),
         "description": _(
             "Variety picks a good mode depending on image size. "
             "Images that are close to the screen proportions use 'Zoom'. "
             "Those that are vastly different use 'Fill with blur'. "
         ),
-        "fn": _os,
+        "fn": _fill_with_blur,  # TODO implement
     },
 ]

--- a/variety/display_modes.py
+++ b/variety/display_modes.py
@@ -1,0 +1,66 @@
+from variety.Util import Util, _
+
+
+def _os():
+    return None, None
+
+
+DISPLAY_MODES = [
+    {
+        "id": "os",
+        "title": _("Controlled by OS settings, not by Variety"),
+        "description": _(
+            "Display mode is controlled by your OS Appearance settings and by what is "
+            "specified in set_wallpaper script for your desktop environment. "
+        ),
+        "fn": _os,
+    },
+    {
+        "id": "zoom",
+        "title": _("Zoom"),
+        "description": _(
+            "Image is zoomed in or out so that it fully fills your primary screen. "
+            "Some parts of the image will be cut out if its resolution is different "
+            "from the screen's. "
+        ),
+        "fn": _os,
+    },
+    {
+        "id": "fill-with-black",
+        "title": _("Fill with black"),
+        "description": _(
+            "Image is zoomed in or out so that it fully fits within your primary screen. "
+            "The rest of the screen is filled with black. "
+        ),
+        "fn": _os,
+    },
+    {
+        "id": "fill-with-blur",
+        "title": _("Fill with blur"),
+        "description": _(
+            "Image is zoomed in or out so that it fully fits within your primary screen. "
+            "The rest of the screen is a filled with blurred version of the image. "
+        ),
+        "fn": _os,
+    },
+    {
+        "id": "smart-with-black",
+        "title": _("Pick dynamically between Zoom and Fill with black"),
+        "description": _(
+            "Variety picks a good mode depending on image size. "
+            "Images that are close to the screen proportions use 'Zoom'. "
+            "Those that are vastly different use 'Fill with black'. "
+        ),
+        "fn": _os,
+    },
+    {
+        "id": "smart-with-blur",
+        "title": _("Pick dynamically between Zoom and Fill with blur"),
+        "description": _(
+            "Variety picks a good mode depending on image size. "
+            "Images that are close to the screen proportions use 'Zoom'. "
+            "Those that are vastly different use 'Fill with blur'. "
+        ),
+        "fn": _os,
+    },
+]

--- a/variety/plugins/IDisplayModesPlugin.py
+++ b/variety/plugins/IDisplayModesPlugin.py
@@ -1,0 +1,99 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+### BEGIN LICENSE
+# Copyright (c) 2012, Peter Levi <peterlevi@peterlevi.com>
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+### END LICENSE
+import abc
+from typing import Callable, List, Optional
+
+from variety.Util import Util
+
+from .IVarietyPlugin import IVarietyPlugin
+
+
+class DisplayModeData:
+    """
+    Contains the data for how to visualize a specific image.
+    set_wallpaper_param - what do we send to the set_wallpaper script, affects OS background options
+    imagemagick_cmd - optional, what command do we run over the image in order to resize it
+    fixed_image_path - optional, if more complex logic needed, generate the image and give its path
+    """
+
+    def __init__(
+        self,
+        set_wallpaper_param: str,
+        imagemagick_cmd: Optional[str] = None,
+        fixed_image_path: Optional[str] = None,
+    ):
+        self.set_wallpaper_param = set_wallpaper_param
+        self.imagemagick_cmd = imagemagick_cmd
+        self.fixed_image_path = fixed_image_path
+
+
+class DisplayMode:
+    """
+    Implements a display mode.
+    Needs a unique id, title to show in the combobox, description to show below the combo when
+    selected, and callable that implements the logic.
+    The callable takes a file path and returns a DisplayModeData object.
+    """
+
+    def __init__(self, id: str, title: str, description: str, fn: Callable[[str], DisplayModeData]):
+        self.id = id
+        self.title = title
+        self.description = description
+        self.fn = fn
+
+
+class StaticDisplayMode(DisplayMode):
+    """
+    A DisplayMode that does not care about the specific file, but implements a uses
+    either a static ImageMagick command, or does no resizing at all and works simply via the
+    set_wallpaper parameter.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        title: str,
+        description: str,
+        set_wallpaper_param: str,
+        imagemagick_cmd: Optional[str] = None,
+    ):
+        def fn(filename: str):
+            w, h = Util.get_primary_display_size()
+            if imagemagick_cmd:
+                final_cmd = imagemagick_cmd.replace("%W", str(w)).replace("%H", str(h))
+            else:
+                final_cmd = None
+            return DisplayModeData(
+                set_wallpaper_param=set_wallpaper_param, imagemagick_cmd=final_cmd
+            )
+
+        super().__init__(id, title, description, fn)
+
+
+class IDisplayModesPlugin(IVarietyPlugin):
+    @abc.abstractmethod
+    def display_modes(self) -> List[DisplayMode]:
+        """
+        Return a list of DisplayModes
+        """
+        return []
+
+    def order(self):
+        """
+        Display modes from IDisplayModesPlugins with lower order get listed before those with
+        higher order
+        """
+        return 100

--- a/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
@@ -19,7 +19,7 @@ class GnomeDisplayModesPlugin(IDisplayModesPlugin):
         return [
             StaticDisplayMode(
                 id="gnome-%s" % mode,
-                title=_("[Provided by the OS] %s") % mode.capitalize(),
+                title=_("[GNOME/Mate/Cinnamon] %s") % mode.capitalize(),
                 description=_(
                     "Variety will instruct the desktop environment to use this mode when "
                     "calling set_wallpaper, and will not itself scale the image, unless needed "
@@ -31,4 +31,4 @@ class GnomeDisplayModesPlugin(IDisplayModesPlugin):
         ]
 
     def order(self):
-        return 1000
+        return 3000

--- a/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
@@ -31,4 +31,4 @@ class GnomeDisplayModesPlugin(IDisplayModesPlugin):
         ]
 
     def order(self):
-        return 100
+        return 1000

--- a/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from variety.plugins.IDisplayModesPlugin import DisplayMode, IDisplayModesPlugin, StaticDisplayMode
+from variety.Util import _
+
+
+class GnomeDisplayModesPlugin(IDisplayModesPlugin):
+    @classmethod
+    def get_info(cls):
+        return {
+            "name": "GnomeDisplayModesPlugin",
+            "description": "Display modes relying on the underlying desktop environment",
+            "version": "1.0",
+            "author": "Peter Levi",
+        }
+
+    def display_modes(self) -> List[DisplayMode]:
+        modes = ["centered", "scaled", "stretched", "zoom", "spanned", "wallpaper"]
+        return [
+            StaticDisplayMode(
+                id="gnome-%s" % mode,
+                title=_("[Provided by the OS] %s") % mode.capitalize(),
+                description=_(
+                    "Variety will instruct the desktop environment to use this mode when "
+                    "calling set_wallpaper, and will not itself scale the image, unless needed "
+                    "by other options, e.g. clock. "
+                ),
+                set_wallpaper_param=mode,
+            )
+            for mode in modes
+        ]
+
+    def order(self):
+        return 1000

--- a/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py
@@ -31,4 +31,4 @@ class GnomeDisplayModesPlugin(IDisplayModesPlugin):
         ]
 
     def order(self):
-        return 1000
+        return 100

--- a/variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py
@@ -20,8 +20,8 @@ class LegacyDisplayModesPlugin(IDisplayModesPlugin):
                 id="os",
                 title=_("[Legacy] Controlled via OS settings, not by Variety. Fast."),
                 description=_(
-                    "Display mode is controlled by your OS Appearance settings and by what is "
-                    "specified in set_wallpaper script for your desktop environment. "
+                    "Display mode is controlled by your OS Appearance settings and by the logic "
+                    "for your desktop environment in ~/.config/variety/scripts/set_wallpaper. "
                     "Provides compatibility with past Variety versions."
                 ),
                 set_wallpaper_param="os",

--- a/variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from variety.plugins.IDisplayModesPlugin import DisplayMode, IDisplayModesPlugin, StaticDisplayMode
+from variety.Util import _
+
+
+class LegacyDisplayModesPlugin(IDisplayModesPlugin):
+    @classmethod
+    def get_info(cls):
+        return {
+            "name": "LegacyDisplayModesPlugin",
+            "description": "Legacy display mode for compatibility with past Variety versions",
+            "version": "1.0",
+            "author": "Peter Levi",
+        }
+
+    def display_modes(self) -> List[DisplayMode]:
+        return [
+            StaticDisplayMode(
+                id="os",
+                title=_("[Legacy] Controlled via OS settings, not by Variety. Fast."),
+                description=_(
+                    "Display mode is controlled by your OS Appearance settings and by what is "
+                    "specified in set_wallpaper script for your desktop environment. "
+                    "Provides compatibility with past Variety versions."
+                ),
+                set_wallpaper_param="os",
+            )
+        ]
+
+    def order(self):
+        return -1000

--- a/variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py
@@ -29,4 +29,4 @@ class LegacyDisplayModesPlugin(IDisplayModesPlugin):
         ]
 
     def order(self):
-        return -1000
+        return 1000

--- a/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
@@ -1,7 +1,37 @@
 from typing import List
 
-from variety.plugins.IDisplayModesPlugin import DisplayMode, IDisplayModesPlugin, StaticDisplayMode
-from variety.Util import _
+from variety.plugins.IDisplayModesPlugin import (
+    DisplayMode,
+    DisplayModeData,
+    IDisplayModesPlugin,
+    StaticDisplayMode,
+)
+from variety.Util import Util, _
+
+IMAGEMAGICK_ZOOM = "-scale %Wx%H^ "
+IMAGEMAGICK_FIT_WITH_BLACK = "-resize %Wx%H -size %Wx%H xc:black +swap -gravity center -composite"
+IMAGEMAGICK_FIT_WITH_BLUR = (
+    "-resize %Wx%H^ -gravity center -extent %Wx%H -scale 10% -blur 0x3 -resize 1000% -clone 0 "
+    "-resize %Wx%H -size %Wx%H -gravity center -composite"
+)
+
+
+def _smart_fn(filename):
+    try:
+        w, h = Util.get_size(filename)
+        dw, dh = Util.get_primary_display_size(hidpi_scaled=True)
+        if w * h * 10 < dw * dh:
+            return DisplayModeData(set_wallpaper_param="wallpaper")
+        else:
+            r1 = w / h
+            r2 = dw / dh
+            if 2 * abs(r1 - r2) / (r1 + r2) < 0.2:
+                return DisplayModeData(set_wallpaper_param="zoom")
+            else:
+                cmd = IMAGEMAGICK_FIT_WITH_BLUR.replace("%W", str(dw)).replace("%H", str(dh))
+                return DisplayModeData(set_wallpaper_param="zoom", imagemagick_cmd=cmd)
+    except:
+        return DisplayModeData(set_wallpaper_param="zoom")
 
 
 class ResizingDisplayModesPlugin(IDisplayModesPlugin):
@@ -16,6 +46,18 @@ class ResizingDisplayModesPlugin(IDisplayModesPlugin):
 
     def display_modes(self) -> List[DisplayMode]:
         return [
+            DisplayMode(
+                id="smart",
+                title=_("Smart: Variety picks best mode based on image size. Recommended."),
+                description=(
+                    "Variety uses the fast OS-provided Zoom mode for images that are close to "
+                    "screen proportions, uses 'Fit & pad with a blurred background' when the image "
+                    "proportions are significantly different - e.g. portraits on a horizontal "
+                    "screen, and uses the OS-provided tiling mode for very small images that would "
+                    "look bad resized."
+                ),
+                fn=_smart_fn,
+            ),
             StaticDisplayMode(
                 id="zoom",
                 title=_("Zoom to fill screen"),
@@ -25,7 +67,7 @@ class ResizingDisplayModesPlugin(IDisplayModesPlugin):
                     "from the screen's. Slower than using native OS resizing options."
                 ),
                 set_wallpaper_param="zoom",
-                imagemagick_cmd="-scale %Wx%H^ ",
+                imagemagick_cmd=IMAGEMAGICK_ZOOM,
             ),
             StaticDisplayMode(
                 id="fill-with-black",
@@ -36,10 +78,10 @@ class ResizingDisplayModesPlugin(IDisplayModesPlugin):
                     "Slower than using native OS resizing options."
                 ),
                 set_wallpaper_param="zoom",
-                imagemagick_cmd="-resize %Wx%H -size %Wx%H xc:black +swap -gravity center -composite",
+                imagemagick_cmd=IMAGEMAGICK_FIT_WITH_BLACK,
             ),
             StaticDisplayMode(
-                id="fill-with-blue",
+                id="fill-with-blur",
                 title=_("Fit within screen, pad with a blurred background. Slow."),
                 description=_(
                     "Image is zoomed in or out so that it fully fits within your primary screen. "
@@ -47,12 +89,9 @@ class ResizingDisplayModesPlugin(IDisplayModesPlugin):
                     "This is a slow option, cause blurring is a slow operation."
                 ),
                 set_wallpaper_param="zoom",
-                imagemagick_cmd=(
-                    "-resize %Wx%H^ -gravity center -extent %Wx%H -blur 0x7 -clone 0 "
-                    "-resize %Wx%H -size %Wx%H -gravity center -composite"
-                ),
+                imagemagick_cmd=IMAGEMAGICK_FIT_WITH_BLUR,
             ),
         ]
 
     def order(self):
-        return 1000
+        return 100

--- a/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
@@ -40,7 +40,7 @@ class ResizingDisplayModesPlugin(IDisplayModesPlugin):
             ),
             StaticDisplayMode(
                 id="fill-with-blue",
-                title=_("Fit within screen, pad with a blurred background (Slow)"),
+                title=_("Fit within screen, pad with a blurred background. Slow."),
                 description=_(
                     "Image is zoomed in or out so that it fully fits within your primary screen. "
                     "The rest of the screen is a filled with blurred version of the image. "
@@ -55,4 +55,4 @@ class ResizingDisplayModesPlugin(IDisplayModesPlugin):
         ]
 
     def order(self):
-        return 100
+        return 1000

--- a/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
@@ -1,0 +1,58 @@
+from typing import List
+
+from variety.plugins.IDisplayModesPlugin import DisplayMode, IDisplayModesPlugin, StaticDisplayMode
+from variety.Util import _
+
+
+class ResizingDisplayModesPlugin(IDisplayModesPlugin):
+    @classmethod
+    def get_info(cls):
+        return {
+            "name": "ResizingDisplayModesPlugin",
+            "description": "Display modes that use image resizing within Variety",
+            "version": "1.0",
+            "author": "Peter Levi",
+        }
+
+    def display_modes(self) -> List[DisplayMode]:
+        return [
+            StaticDisplayMode(
+                id="zoom",
+                title=_("Zoom to fill screen"),
+                description=_(
+                    "Image is zoomed in or out so that it fully fills your primary screen. "
+                    "Some parts of the image will be cut out if its resolution is different "
+                    "from the screen's. Slower than using native OS resizing options."
+                ),
+                set_wallpaper_param="zoom",
+                imagemagick_cmd="-scale %Wx%H^ ",
+            ),
+            StaticDisplayMode(
+                id="fill-with-black",
+                title=_("Fit within screen, pad with black"),
+                description=_(
+                    "Image is zoomed in or out so that it fully fits within your primary screen. "
+                    "The rest of the screen is filled with black. "
+                    "Slower than using native OS resizing options."
+                ),
+                set_wallpaper_param="zoom",
+                imagemagick_cmd="-resize %Wx%H -size %Wx%H xc:black +swap -gravity center -composite",
+            ),
+            StaticDisplayMode(
+                id="fill-with-blue",
+                title=_("Fit within screen, pad with a blurred background (Slow)"),
+                description=_(
+                    "Image is zoomed in or out so that it fully fits within your primary screen. "
+                    "The rest of the screen is a filled with blurred version of the image. "
+                    "This is a slow option, cause blurring is a slow operation."
+                ),
+                set_wallpaper_param="zoom",
+                imagemagick_cmd=(
+                    "-resize %Wx%H^ -gravity center -extent %Wx%H -blur 0x7 -clone 0 "
+                    "-resize %Wx%H -size %Wx%H -gravity center -composite"
+                ),
+            ),
+        ]
+
+    def order(self):
+        return 100

--- a/variety/plugins/builtin/downloaders/UnsplashDownloader.py
+++ b/variety/plugins/builtin/downloaders/UnsplashDownloader.py
@@ -97,7 +97,7 @@ class UnsplashDownloader(SimpleDownloader):
                     continue
 
                 image_url = item["urls"]["full"] + "&w={}".format(
-                    max(1980, int(Util.get_screen_width() * 1.2))
+                    max(1980, int(Util.get_primary_display_size()[0] * 1.2))
                 )
                 origin_url = item["links"]["html"] + UnsplashDownloader.UTM_PARAMS
 


### PR DESCRIPTION
- Adds pluginnable configurations for choosing the "display mode", e.g. zoom, tile, span, etc. 
- Includes options implemented directly inside Variety, e.g. "Fit with blurred background", and a smart mode where Variety picks the best mode depending on image size and proportions.
- Also adds an option to auto-rotate the image according to EXIF.
- Reorganizes the Preferences UI into more "focused" pages to make space for the new options.
- Faster Heavy and Soft blur filters
![Screenshot from 2022-05-07 00-29-37](https://user-images.githubusercontent.com/1457048/167218944-31ca8e57-9134-4175-8b4e-bbe8427d72ea.png)

