### PR TITLE
Fix for autostart not launching Variety in Gnome DE

### DIFF
--- a/data/variety-autostart.desktop.template
+++ b/data/variety-autostart.desktop.template
@@ -2,7 +2,7 @@
 Name=Variety
 Comment=Variety Wallpaper Changer
 Categories=GNOME;GTK;Utility;
-Exec=sleep 20 && {VARIETY_PATH} --profile {PROFILE_PATH}
+Exec=/bin/bash -c "sleep 20 && {VARIETY_PATH} --profile {PROFILE_PATH}"
 MimeType=text/uri-list;x-scheme-handler/variety;x-scheme-handler/vrty;
 Icon=variety
 Terminal=false


### PR DESCRIPTION
Hello this PR is for issue #519 if you feel it's an acceptable solution.  
I'm wrapping a `/bin/bash -c` around the Exec command in the autostart .desktop entry.  
It seems the current `sleep .. && .. ` works for some [but not always](https://askubuntu.com/a/28695/26436).
Wrapping it in /bin/bash -c should make it more compatible with DEs.  
