### PR TITLE
Add support for libnotify 0.8

### DIFF
--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -66,7 +66,7 @@ from variety_lib import varietyconfig
 # fmt: off
 import gi  # isort:skip
 
-gi.require_version("Notify", "0.7")
+gi.require_version("Notify", "0.8")
 from gi.repository import Gdk, Gio, GObject, Gtk, Notify  # isort:skip
 Notify.init("Variety")
 # fmt: on

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -66,7 +66,10 @@ from variety_lib import varietyconfig
 # fmt: off
 import gi  # isort:skip
 
-gi.require_version("Notify", "0.8")
+try:
+    gi.require_version("Notify", "0.7")
+except:
+    gi.require_version("Notify", "0.7")
 from gi.repository import Gdk, Gio, GObject, Gtk, Notify  # isort:skip
 Notify.init("Variety")
 # fmt: on

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -69,7 +69,7 @@ import gi  # isort:skip
 try:
     gi.require_version("Notify", "0.7")
 except:
-    gi.require_version("Notify", "0.7")
+    gi.require_version("Notify", "0.8")
 from gi.repository import Gdk, Gio, GObject, Gtk, Notify  # isort:skip
 Notify.init("Variety")
 # fmt: on


### PR DESCRIPTION
After the actualization of `libnotify` to version 0.8 variety wouldn't open because it required version 0.7. I have checked the change log from `libnotify` and changing the requirement to the new version shouldn't break anything, I am testing it right now on my Arch installation and it works perfectly fine.