### PR TITLE
Fix awesome wallpaper maximized with multiple monitors

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -283,7 +283,7 @@ fi
 # NOTE: This config will change the wallpaper after your current awesome theme sets it.
 # As such, the theme's wallpaper will briefly appear before being replaced with Variety's wallpaper.
 if [[ "$XDG_SESSION_DESKTOP $DESKTOP_STARTUP_ID $DESKTOP_SESSION $XDG_CURRENT_DESKTOP" == *"awesome"* ]]; then
-	echo "local gears = require(\"gears\") gears.wallpaper.maximized(\"$1\", nil)" | awesome-client
+	echo "for s in screen do require(\"gears\").wallpaper.maximized(\"$1\", s) end" | awesome-client
 fi
 
 # =====================================================================================


### PR DESCRIPTION
The current set_wallpaper script maximizes the wallpaper such that it is split between two monitors. After this change, each monitor will have the full wallpaper maximized to the monitor's full size.