### PR TITLE
Fix #418: Awesome WM dual monitor maximised wallpaper

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -283,7 +283,7 @@ fi
 # NOTE: This config will change the wallpaper after your current awesome theme sets it.
 # As such, the theme's wallpaper will briefly appear before being replaced with Variety's wallpaper.
 if [[ "$XDG_SESSION_DESKTOP $DESKTOP_STARTUP_ID $DESKTOP_SESSION $XDG_CURRENT_DESKTOP" == *"awesome"* ]]; then
-	echo "local gears = require(\"gears\") gears.wallpaper.maximized(\"$1\", nil)" | awesome-client
+	echo "for s in screen do require(\"gears\").wallpaper.maximized(\"$1\", s) end" | awesome-client
 fi
 
 # =====================================================================================


### PR DESCRIPTION
Before this change, the wallpaper on Awesome WM with a dual monitor setup was split between the monitors. After the change, both monitors display a complete, maximized, version of the same wallpaper.

I'm using this fix in my daily driver machine. Currently, I need to keep set_wallpaper in my dotfiles and merge it with every variety update: https://github.com/elmeriniemela/dotfiles/commits/master/.config/variety/scripts/set_wallpaper