### PR TITLE
ADD abslute path for gsettings to avoid conflicts whit linuxbrew

### DIFF
--- a/data/scripts/get_wallpaper
+++ b/data/scripts/get_wallpaper
@@ -8,7 +8,7 @@ desktop="$DESKTOP_SESSION"
 
 # Gnome 3, Unity:
 if [ "$desktop" == "ubuntu" ] || [ "$XDG_CURRENT_DESKTOP" == "Unity" ]; then
-        gsettings get org.gnome.desktop.background picture-uri
+        /usr/bin/gsettings get org.gnome.desktop.background picture-uri
 
 # XFCE
 elif [ "$desktop" == "xubuntu" ] || [ "$XDG_CURRENT_DESKTOP" == "XFCE" ]; then
@@ -28,11 +28,11 @@ elif [ "$XDG_CURRENT_DESKTOP" == "LXQt" ]; then
 
 # MATE
 elif [ "$XDG_CURRENT_DESKTOP" == "MATE" ]; then
-        gsettings get org.mate.background picture-filename
+        /usr/bin/gsettings get org.mate.background picture-filename
 
 # Cinnamon after 2.0
 elif [ "$desktop" == "Cinnamon" ] || [ "$XDG_CURRENT_DESKTOP" == "X-Cinnamon" ]; then
-        gsettings get org.cinnamon.desktop.background picture-uri
+        /usr/bin/gsettings get org.cinnamon.desktop.background picture-uri
 
 # KDE Plasma 5
 elif [ "$XDG_CURRENT_DESKTOP" == "KDE" ] && [ "$KDE_SESSION_VERSION" == "5" ]; then
@@ -45,7 +45,7 @@ elif [ "$XDG_CURRENT_DESKTOP" == "Trinity" ]; then
 
 # All above fails => fallback to the Gnome 3 way
 else
-        gsettings get org.gnome.desktop.background picture-uri
+        /usr/bin/gsettings get org.gnome.desktop.background picture-uri
 fi
 
 # Feh

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -172,32 +172,32 @@ if [ "${KDE_FULL_SESSION}" == "true" ]; then
 fi
 
 # Gnome 3, Unity
-gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2> /dev/null
-gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2> /dev/null
+/usr/bin/gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2> /dev/null
+/usr/bin/gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2> /dev/null
 if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
-    gsettings set org.gnome.desktop.background picture-options "$4"
+    /usr/bin/gsettings set org.gnome.desktop.background picture-options "$4"
 fi
-if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ]; then
-    gsettings set org.gnome.desktop.background picture-options 'zoom'
+if [ "$(/usr/bin/gsettings get org.gnome.desktop.background picture-options)" == "'none'"  ]; then
+    /usr/bin/gsettings set org.gnome.desktop.background picture-options 'zoom'
 fi
 
 # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch
-gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2> /dev/null
+/usr/bin/gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2> /dev/null
 if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
-    gsettings set org.gnome.desktop.screensaver picture-options "$4"
+    /usr/bin/gsettings set org.gnome.desktop.screensaver picture-options "$4"
 fi
-if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
-    gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
+if [ "$(/usr/bin/gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
+    /usr/bin/gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
 fi
 
 # Deepin
-if [ "$(gsettings list-schemas | grep -c com.deepin.wrap.gnome.desktop.background)" -ge 1 ]; then
-    gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "file://$WP"
+if [ "$(/usr/bin/gsettings list-schemas | grep -c com.deepin.wrap.gnome.desktop.background)" -ge 1 ]; then
+    /usr/bin/gsettings set com.deepin.wrap.gnome.desktop.background picture-uri "file://$WP"
     if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
-        gsettings set com.deepin.wrap.gnome.desktop.background picture-options "$4"
+        /usr/bin/gsettings set com.deepin.wrap.gnome.desktop.background picture-options "$4"
     fi
-    if [ "$(gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ]; then
-        gsettings set com.deepin.wrap.gnome.desktop.background picture-options 'zoom'
+    if [ "$(/usr/bin/gsettings get com.deepin.wrap.gnome.desktop.background picture-options)" == "'none'" ]; then
+        /usr/bin/gsettings set com.deepin.wrap.gnome.desktop.background picture-options 'zoom'
     fi
 fi
 
@@ -261,21 +261,21 @@ if [ "$XDG_CURRENT_DESKTOP" == "Trinity" ]; then
 fi
 
 # MATE after 1.6
-gsettings set org.mate.background picture-filename "$WP" 2> /dev/null
-if [ "$(gsettings get org.mate.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
-	gsettings set org.mate.desktop.background picture-options 'zoom'
+/usr/bin/gsettings set org.mate.background picture-filename "$WP" 2> /dev/null
+if [ "$(/usr/bin/gsettings get org.mate.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
+	/usr/bin/gsettings set org.mate.desktop.background picture-options 'zoom'
 fi
 if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
-  gsettings set org.mate.desktop.background picture-options "$4"
+  /usr/bin/gsettings set org.mate.desktop.background picture-options "$4"
 fi
 
 # Cinnamon after 2.0
-gsettings set org.cinnamon.desktop.background picture-uri "file://$WP" 2> /dev/null
-if [ "$(gsettings get org.cinnamon.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
-	gsettings set org.cinnamon.desktop.background picture-options 'zoom'
+/usr/bin/gsettings set org.cinnamon.desktop.background picture-uri "file://$WP" 2> /dev/null
+if [ "$(/usr/bin/gsettings get org.cinnamon.desktop.background picture-options 2>/dev/null)" == "'none'" ]; then
+	/usr/bin/gsettings set org.cinnamon.desktop.background picture-options 'zoom'
 fi
 if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
-  gsettings set org.cinnamon.desktop.background picture-options "$4"
+  /usr/bin/gsettings set org.cinnamon.desktop.background picture-options "$4"
 fi
 
 # Awesome Window Manager


### PR DESCRIPTION
It is safer to use the full path of gsettings to avoid conflicts with other gsettings that may be using different backends. For example, when using gsettings from the Linuxbrew GLib, it uses the keyfile backend, whereas in Ubuntu the backend for gsettings is already dconf.

Using the full path eliminates the possibility of running an unintended version of gsettings, which could lead to unexpected results. Additionally, it ensures that the intended version of gsettings is used consistently across all scripts and applications, regardless of the user's PATH environment variable.

I suggest adding a note in the documentation or wiki to encourage users to use the full path of gsettings, such as "/usr/bin/gsettings", to avoid conflicts.

Thank you for considering this suggestion.