### PR TITLE
Fix #608: Filter watermarked Unsplash+ wallpapers

### DIFF
--- a/variety/plugins/builtin/downloaders/UnsplashDownloader.py
+++ b/variety/plugins/builtin/downloaders/UnsplashDownloader.py
@@ -100,6 +100,9 @@ class UnsplashDownloader(SimpleDownloader):
                     max(1980, int(Util.get_primary_display_size()[0] * 1.2))
                 )
                 origin_url = item["links"]["html"] + UnsplashDownloader.UTM_PARAMS
+                
+                if "plus.unsplash.com/" in image_url:  # exclude watermarked wallpapers
+                    continue
 
                 extra_metadata = {
                     "sourceType": "unsplash",


### PR DESCRIPTION
This is a beyond simple fix that simply checks if the URL returned by the API contains plus.unsplash.com