### PR TITLE
Only set Plasma wallpaper if the plugin is already org.kde.image

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -139,12 +139,12 @@ if [ "${KDE_FULL_SESSION}" == "true" ]; then
         fi
 
         QT_SELECT=5 $qdbus_command org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "
-        var allDesktops = desktops();
-        for (i=0; i < allDesktops.length; i++) {
-            d = allDesktops[i];
-            d.wallpaperPlugin = 'org.kde.image';
-            d.currentConfigGroup = Array('Wallpaper', 'org.kde.image', 'General');
-            d.writeConfig('Image', 'file://""$WP""')
+        let allDesktops = desktops();
+        for (let d of allDesktops) {
+            if (d.wallpaperPlugin == 'org.kde.image') {
+                d.currentConfigGroup = Array('Wallpaper', 'org.kde.image', 'General');
+                d.writeConfig('Image', 'file://""$WP""')
+            }
         }
         "
         # Reuse the exit code from qdbus


### PR DESCRIPTION
If the user has multiple desktops where some aren't using `org.kde.image` - leave them be. The user can set the wallpaper plugin to the "Image" plugin for each desktop they want the variety slideshow on.

Probably the correct way to handle this would be to introduce a new Plasma wallpaper plugin called "Variety" only update desktops that are specifically set to "Variety", but this is a bit too much for this PR. Let me know if you are interested and I can have a go at that.