### PR TITLE
Add regex name filter

### DIFF
--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -109,7 +109,7 @@ min_rating = 4
 # name_regex_enabled = <True or False>
 # name_regex = <regex>
 name_regex_enabled = False
-name_regex = *
+name_regex = .*
 
 # What parts of the initial wizard have we covered
 smart_notice_shown = False

--- a/data/config/variety.conf
+++ b/data/config/variety.conf
@@ -105,6 +105,12 @@ lightness_mode = 0
 min_rating_enabled = False
 min_rating = 4
 
+# Use a name regex filter?
+# name_regex_enabled = <True or False>
+# name_regex = <regex>
+name_regex_enabled = False
+name_regex = *
+
 # What parts of the initial wizard have we covered
 smart_notice_shown = False
 smart_register_shown = False

--- a/data/ui/PreferencesVarietyDialog.ui
+++ b/data/ui/PreferencesVarietyDialog.ui
@@ -3278,6 +3278,83 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox" id="box9">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel" id="label68">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">15</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="label" translatable="yes">Name</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box10">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkCheckButton" id="name_regex_enabled">
+                            <property name="label" translatable="yes">Matches RegEx: </property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">30</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="delayed_apply" swapped="no"/>
+                            <signal name="toggled" handler="on_name_regex_enabled_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="name_regex">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">False</property>
+                            <property name="invisible_char">•</property>
+                            <property name="max_width_chars">50</property>
+                            <signal name="changed" handler="delayed_apply" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+                <child>
                   <placeholder/>
                 </child>
               </object>

--- a/po/variety.pot
+++ b/po/variety.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-27 21:49-0700\n"
+"POT-Creation-Date: 2023-05-31 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,575 +17,83 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../variety/AddFlickrDialog.py:148
-msgid "No images found"
+#: ../variety/display_modes.py:33
+msgid "Controlled by OS settings, not by Variety. Fastest option."
 msgstr ""
 
-#: ../variety/FlickrDownloader.py:45
-msgid "Images from Flickr"
-msgstr ""
-
-#: ../variety/FolderChooser.py:67
-msgid "Choose a folder"
-msgstr ""
-
-#: ../variety/FolderChooser.py:70 ../variety/PreferencesVarietyDialog.py:588
-#: ../variety/PreferencesVarietyDialog.py:629
-msgid "Cancel"
-msgstr ""
-
-#: ../variety/FolderChooser.py:70
-msgid "OK"
-msgstr ""
-
-#: ../variety/ImageFetcher.py:62 ../variety/ImageFetcher.py:108
-msgid "Fetching"
-msgstr ""
-
-#: ../variety/ImageFetcher.py:66 ../variety/ImageFetcher.py:76
-#: ../variety/ImageFetcher.py:83 ../variety/ImageFetcher.py:117
-#: ../variety/VarietyWindow.py:2484
-msgid "Not an image"
-msgstr ""
-
-#: ../variety/ImageFetcher.py:123
-msgid "Image too small, ignoring it"
-msgstr ""
-
-#: ../variety/ImageFetcher.py:148
-#, python-format
-msgid "Sorry, got %s error..."
-msgstr ""
-
-#: ../variety/ImageFetcher.py:149
-msgid "This means the link is no longer valid"
-msgstr ""
-
-#: ../variety/ImageFetcher.py:153
-msgid "Fetch failed for some reason"
-msgstr ""
-
-#: ../variety/ImageFetcher.py:155
+#: ../variety/display_modes.py:35
 msgid ""
-"To get more information, please run Variety from terminal with -v option and "
-"retry the action"
+"Display mode is controlled by your OS Appearance settings and by what is "
+"specified in set_wallpaper script for your desktop environment. "
 msgstr ""
 
-#: ../variety/indicator.py:63 ../variety/indicator.py:110
-#: ../variety/indicator.py:179
-msgid "_Next"
+#: ../variety/display_modes.py:42
+msgid "Zoom"
 msgstr ""
 
-#: ../variety/indicator.py:68 ../variety/indicator.py:115
-#: ../variety/indicator.py:184
-msgid "_Previous"
-msgstr ""
-
-#: ../variety/indicator.py:75
-msgid "Current desktop wallpaper"
-msgstr ""
-
-#: ../variety/indicator.py:79
-msgid "Show origin"
-msgstr ""
-
-#: ../variety/indicator.py:90 ../variety/ThumbsManager.py:177
-#: ../variety/VarietyWindow.py:729
-msgid "Copy to _Favorites"
-msgstr ""
-
-#: ../variety/indicator.py:95 ../variety/VarietyWindow.py:738
-#: ../data/ui/PreferencesVarietyDialog.ui:3289
-msgid "Move to Favorites"
-msgstr ""
-
-#: ../variety/indicator.py:101 ../variety/ThumbsManager.py:197
-msgid "Delete to _Trash"
-msgstr ""
-
-#: ../variety/indicator.py:120 ../variety/indicator.py:189
-msgid "_Next, skipping forward history"
-msgstr ""
-
-#: ../variety/indicator.py:130
+#: ../variety/display_modes.py:44
 msgid ""
-"Tip: Scroll wheel over icon\n"
-"for Next and Previous"
+"Image is zoomed in or out so that it fully fills your primary screen. Some "
+"parts of the image will be cut out if its resolution is different from the "
+"screen's. "
 msgstr ""
 
-#: ../variety/indicator.py:136 ../variety/indicator.py:200
-#: ../variety/VarietyWindow.py:873 ../variety/VarietyWindow.py:895
-msgid "Pause on current"
+#: ../variety/display_modes.py:52
+msgid "Fill with black"
 msgstr ""
 
-#: ../variety/indicator.py:140
-msgid "_Image"
-msgstr ""
-
-#: ../variety/indicator.py:147 ../variety/ThumbsManager.py:206
-msgid "Where is it from?"
-msgstr ""
-
-#: ../variety/indicator.py:151
-msgid "Show without effects"
-msgstr ""
-
-#: ../variety/indicator.py:161
-msgid "Google Image Search"
-msgstr ""
-
-#: ../variety/indicator.py:168 ../variety/ThumbsManager.py:169
-msgid "Set EXIF Rating"
-msgstr ""
-
-#: ../variety/indicator.py:206 ../variety/VarietyWindow.py:902
-msgid "Save to Favorites"
-msgstr ""
-
-#: ../variety/indicator.py:211
-msgid "View Favorites..."
-msgstr ""
-
-#: ../variety/indicator.py:218
-msgid "Copy to Clipboard"
-msgstr ""
-
-#: ../variety/indicator.py:228
-msgid "Google Quote"
-msgstr ""
-
-#: ../variety/indicator.py:233
-msgid "Google Author"
-msgstr ""
-
-#: ../variety/indicator.py:240 ../variety/indicator.py:296
-msgid "Preferences..."
-msgstr ""
-
-#: ../variety/indicator.py:250
-msgid "Turn off"
-msgstr ""
-
-#: ../variety/indicator.py:255
-msgid "_Quote"
-msgstr ""
-
-#: ../variety/indicator.py:262
-msgid "_History"
-msgstr ""
-
-#: ../variety/indicator.py:268
-msgid "_Wallpaper Selector"
-msgstr ""
-
-#: ../variety/indicator.py:276
-msgid "Recent _Downloads"
-msgstr ""
-
-#: ../variety/indicator.py:284
-msgid "Start Slideshow"
-msgstr ""
-
-#: ../variety/indicator.py:300
-msgid "About"
-msgstr ""
-
-#: ../variety/indicator.py:304 ../data/ui/PreferencesVarietyDialog.ui:3991
-msgid "Donate"
-msgstr ""
-
-#: ../variety/indicator.py:308
-msgid "Quit"
-msgstr ""
-
-#: ../variety/__init__.py:121
-msgid "Terminating signal received, quitting..."
-msgstr ""
-
-#: ../variety/__init__.py:195
+#: ../variety/display_modes.py:54
 msgid ""
-"Variety is already running. Sending the command to the running instance."
+"Image is zoomed in or out so that it fully fits within your primary screen. "
+"The rest of the screen is filled with black. "
 msgstr ""
 
-#: ../variety/PreferencesVarietyDialog.py:85
-msgid " (Profile: {})"
+#: ../variety/display_modes.py:61
+msgid "Fill with blur. Slow."
 msgstr ""
 
-#: ../variety/PreferencesVarietyDialog.py:87
-#: ../data/ui/PreferencesVarietyDialog.ui:121
-msgid "Variety Preferences"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:246
-msgid "All"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:396
-#: ../variety/PreferencesVarietyDialog.py:595
-#: ../data/ui/PreferencesVarietyDialog.ui:342
-msgid "Images"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:396
-msgid "Add individual wallpaper images"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:398
-msgid "Folders"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:399
-msgid "Searched recursively for up to 10000 images, shown in random order"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:405
-msgid "Sequential Albums (order by filename)"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:406
-msgid "Searched recursively for images, shown in sequence (by filename)"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:412
-msgid "Sequential Albums (order by date)"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:413
-msgid "Searched recursively for images, shown in sequence (by file date)"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:419 ../data/ui/AddFlickrDialog.ui:83
-msgid "Flickr"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:419
-msgid "Fetch images from Flickr"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:461
-msgid "Remove the source, keep the files"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:463
-msgid "Remove the sources, keep the files"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:474
-msgid "Remove the source and delete the downloaded files"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:476
-msgid "Remove the sources and delete the downloaded files"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:511
-#, python-format
+#: ../variety/display_modes.py:63
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:97
 msgid ""
-"Using this source requires wallpaper changing enabled at intervals of %d "
-"minutes or less. Settings were adjusted automatically."
+"Image is zoomed in or out so that it fully fits within your primary screen. "
+"The rest of the screen is a filled with blurred version of the image. "
 msgstr ""
 
-#: ../variety/PreferencesVarietyDialog.py:585
-msgid "Add Images"
+#: ../variety/display_modes.py:70
+msgid "Pick dynamically between Zoom and Fill with black"
 msgstr ""
 
-#: ../variety/PreferencesVarietyDialog.py:588
-#: ../variety/PreferencesVarietyDialog.py:629
-msgid "Add"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:613
+#: ../variety/display_modes.py:72
 msgid ""
-"Add Folders - Only add the root folders, subfolders are searched recursively"
+"Variety picks a good mode depending on image size. Images that are close to "
+"the screen proportions use 'Zoom'. Those that are vastly different use 'Fill "
+"with black'. "
 msgstr ""
 
-#: ../variety/PreferencesVarietyDialog.py:617
+#: ../variety/display_modes.py:80
+msgid "Pick dynamically between Zoom and Fill with blur. Slow."
+msgstr ""
+
+#: ../variety/display_modes.py:82
 msgid ""
-"Add Sequential Albums (ordered by filename). Subfolders are searched "
-"recursively."
+"Variety picks a good mode depending on image size. Images that are close to "
+"the screen proportions use 'Zoom'. Those that are vastly different use 'Fill "
+"with blur'. "
 msgstr ""
 
-#: ../variety/PreferencesVarietyDialog.py:621
+#: ../variety/plugins/builtin/quotes/LocalFilesSource.py:37
 msgid ""
-"Add Sequential Albums (ordered by date). Subfolders are searched recursively."
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:775
-#: ../data/ui/PreferencesVarietyDialog.ui:3304
-msgid "Edit..."
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:777
-msgid "Open Folder"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:783
-msgid "View Image"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:1166
-#: ../variety/PreferencesVarietyDialog.py:1173
-msgid "No write permissions"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:1248
-msgid "Could not adjust permissions"
-msgstr ""
-
-#: ../variety/PreferencesVarietyDialog.py:1249
-#, python-format
-msgid ""
-"You may try manually running this command:\n"
-"sudo chmod %s \"%s\""
-msgstr ""
-
-#: ../variety/QuotesEngine.py:243
-msgid "No quote plugins"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:243
-msgid "There are no quote plugins installed"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:250
-msgid "No suitable quote plugins"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:251
-msgid ""
-"You have no quote plugins which support searching by keywords and authors"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:266
-msgid "Could not fetch quotes"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:267
-msgid "Quotes services may be down, we will continue trying"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:271
-msgid "Could not find quotes"
-msgstr ""
-
-#: ../variety/QuotesEngine.py:272
-msgid "Maybe you are searching for something very obscure?"
-msgstr ""
-
-#: ../variety/Texts.py:21
-msgid "Keep original"
-msgstr ""
-
-#: ../variety/Texts.py:22
-msgid "Grayscale"
-msgstr ""
-
-#: ../variety/Texts.py:23
-msgid "Heavy blur"
-msgstr ""
-
-#: ../variety/Texts.py:24
-msgid "Soft blur"
-msgstr ""
-
-#: ../variety/Texts.py:25
-msgid "Oil painting"
-msgstr ""
-
-#: ../variety/Texts.py:26
-msgid "Pointilism"
-msgstr ""
-
-#: ../variety/Texts.py:27
-msgid "Pixellate"
-msgstr ""
-
-#: ../variety/Texts.py:31
-msgid "The Favorites folder"
-msgstr ""
-
-#: ../variety/Texts.py:32
-msgid "The Fetched folder"
-msgstr ""
-
-#: ../variety/Texts.py:35
-msgid ""
-"Recommended by Variety. Adapts to your taste as you mark images as favorite "
-"or trash."
-msgstr ""
-
-#: ../variety/Texts.py:39
-msgid ""
-"Latest favorites by the other users of Variety. [May contain NSFW images]"
-msgstr ""
-
-#: ../variety/Texts.py:41
-msgid "Random wallpapers from Desktoppr.co"
-msgstr ""
-
-#: ../variety/Texts.py:42
-msgid "NASA's Astronomy Picture of the Day"
-msgstr ""
-
-#: ../variety/Texts.py:43
-msgid "Bing Photo of the Day"
-msgstr ""
-
-#: ../variety/Texts.py:46
-msgid "High-resolution photos from Unsplash.com"
-msgstr ""
-
-#: ../variety/Texts.py:54
-msgid ""
-"You can change the wallpaper back and forth by scrolling the mouse wheel on "
-"top of the indicator icon."
-msgstr ""
-
-#: ../variety/Texts.py:57
-#, python-brace-format
-msgid ""
-"If you want to run custom commands every time the wallpaper changes or if "
-"you use an alternative desktop environment, please edit the scripts in "
-"{PROFILE_PATH}scripts. There are examples there for various desktop "
-"environments."
-msgstr ""
-
-#: ../variety/Texts.py:60
-msgid ""
-"Variety can be controlled from the command line and you can use this to "
-"define keyboard shortcuts for the operations you use most often. Run "
-"\"variety --help\" to see all available commands."
-msgstr ""
-
-#: ../variety/Texts.py:63
-msgid ""
-"You can drop image links or files on the launcher icon to download them and "
-"use them as wallpapers. For quicker downloading from a specific site, you "
-"can also use clipboard monitoring (see \"Manual downloading\" tab)."
-msgstr ""
-
-#: ../variety/Texts.py:66
-msgid ""
-"Applying a heavy blurring filter is a great way to get abstract-looking and "
-"unobtrusive, yet colorful wallpapers, similar in spirit to the default one "
-"in Ubuntu."
-msgstr ""
-
-#: ../variety/Texts.py:69
-#, python-brace-format
-msgid ""
-"Adding your own custom filters is quite easy: open {PROFILE_PATH}variety."
-"conf in an editor and use the existing filters as an example. Every filter "
-"is just a line of options to be passed to ImageMagick's convert command."
-msgstr ""
-
-#: ../variety/Texts.py:72
-msgid ""
-"When you select an image source, its images are displayed in a window at the "
-"bottom of the screen. Click an image there to set is as wallpaper. Right-"
-"click to close the window, to modify its appearance or to perform file "
-"operations. You can select multiple image sources to create a \"merged\" "
-"thumbnail view of all of them. Please mind that thumbnail view is limited to "
-"several hundred randomly selected images."
-msgstr ""
-
-#: ../variety/Texts.py:75
-#, python-brace-format
-msgid ""
-"To enable desktop notifications when the wallpaper changes, uncomment the "
-"two lines at the bottom of {PROFILE_PATH}scripts/set_wallpaper."
-msgstr ""
-
-#: ../variety/Texts.py:78
-msgid ""
-"Variety's indicator icon is themeable - if you you choose the \"Light\" "
-"option for the icon, Variety will first check if the current GTK theme has "
-"an icon named \"variety-indicator\" and will use it instead of the bundled "
-"light icon."
-msgstr ""
-
-#: ../variety/Texts.py:81
-#, python-brace-format
-msgid ""
-"When you choose to save quotes to Favorites, these are by default saved to "
-"{PROFILE_PATH}favorite_quotes.txt. This file is compatible with Variety's "
-"local files quote source. If you want to use it - copy it to ~/.config/"
-"variety/pluginconfig/quotes/ and enable the Local Files quote source. This "
-"file is also compatible with the Unix fortune utility."
-msgstr ""
-
-#: ../variety/ThumbsManager.py:41 ../data/ui/PreferencesVarietyDialog.ui:1242
-msgid "Bottom"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:42
-msgid "Top"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:43
-msgid "Left"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:44 ../data/ui/PreferencesVarietyDialog.ui:1173
-msgid "Right"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:117
-msgid "Position"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:121 ../data/ui/PreferencesVarietyDialog.ui:2771
-msgid "Size"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:125
-msgid "Maximum Shown Images"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:139
-msgid "Show Containing Folder"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:152 ../variety/VarietyWindow.py:760
-msgid "Fetched: Show Origin"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:154 ../variety/VarietyWindow.py:764
-#: ../variety/VarietyWindow.py:886
-#, python-format
-msgid "View at %s"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:186 ../variety/VarietyWindow.py:730
-msgid "Move to _Favorites"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:220
-msgid "Close"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:240
-msgid "Could not set EXIF rating"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:260
-msgid "Unrated"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:267
-msgid "Rejected"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:380
-msgid "Variety History"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:382
-msgid "Variety Recent Downloads"
-msgstr ""
-
-#: ../variety/ThumbsManager.py:384
-msgid "Variety Images"
+"Displays quotes, defined in local text files.\n"
+"Put your own txt files in: {}pluginconfig/quotes/.\n"
+"The file format is:\n"
+"\n"
+"quote -- author\n"
+".\n"
+"second quote -- another author\n"
+".\n"
+"etc...\n"
+"\n"
+"Example: http://rvelthuis.de/zips/quotes.txt"
 msgstr ""
 
 #: ../variety/VarietyOptionParser.py:51
@@ -744,192 +252,38 @@ msgid ""
 "mutually exclusive"
 msgstr ""
 
-#: ../variety/VarietyWindow.py:725 ../variety/VarietyWindow.py:902
-#: ../variety/VarietyWindow.py:2883
-msgid "Already in Favorites"
+#: ../variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py:21
+msgid "[Legacy] Controlled via OS settings, not by Variety. Fast."
 msgstr ""
 
-#: ../variety/VarietyWindow.py:762
-#, python-format
-msgid "Source: %s"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:828
-msgid "Unknown"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:850
-#, python-format
-msgid "Author: %s"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:875 ../variety/VarietyWindow.py:897
-msgid "Resume regular changes"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1048
-msgid "Filtering too strict?"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1049
+#: ../variety/plugins/builtin/display_modes/LegacyDisplayModesPlugin.py:23
 msgid ""
-"Variety is finding too few images that match your image filtering criteria"
+"Display mode is controlled by your OS Appearance settings and by the logic "
+"for your desktop environment in ~/.config/variety/scripts/set_wallpaper. "
+"Provides compatibility with past Variety versions."
 msgstr ""
 
-#: ../variety/VarietyWindow.py:1638
-msgid "Please add more image sources or wait for some downloads"
+#: ../variety/plugins/builtin/quotes/GoodreadsSource.py:129
+msgid "Fetches quotes from Goodreads.com"
 msgstr ""
 
-#: ../variety/VarietyWindow.py:1640
-msgid "Please add more image sources"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1641
-msgid "No more wallpapers"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1910
-msgid "Current wallpaper is not in the image sources"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1943
-#, python-format
-msgid ""
-"Could not move to %s. You probably don't have permissions to move this file."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1950
-#, python-format
-msgid ""
-"Could not copy to %s. You probably don't have permissions to copy this file."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1975 ../variety/VarietyWindow.py:1998
-msgid "Cannot delete"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1976
-#, python-format
-msgid "You don't have permissions to delete %s to Trash."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:1999
-msgid "Deleting to trash failed, check variety.log for more information."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2325
-msgid ""
-"I will open an editor with the config file and apply the changes after you "
-"save and close the editor."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2490
-msgid "Added to queue"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2491 ../variety/VarietyWindow.py:2504
-msgid "Press Next to see it"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2503
-msgid "Fetched"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2554
-msgid "Unsupported source type"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2555 ../variety/VarietyWindow.py:2603
-msgid "Are you running the most recent version of Variety?"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2565
-msgid "New image source added"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2567
-msgid "Image source already exists, enabling it"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2593
-msgid "Fetched and applied"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2598
-msgid "It works!"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2598
-msgid "Yay, Variety links work. Great!"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2602
-msgid "Unsupported command"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2607
-msgid "Could not process the given variety:// URL"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2608
-msgid "Run with logging enabled to see details"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2970
-msgid "Variety: New desktop entry"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2972
-msgid ""
-"We created a new desktop entry in ~/.local/share/applications to run Variety "
-"with profile \"{}\". Find it in the application launcher."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2997
-msgid "Variety: Created autostart desktop entry"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:2999
-msgid ""
-"We created a new desktop entry in ~/.config/autostart. Variety should start "
-"automatically on next login."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:3006
-msgid "Could not create autostart entry"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:3008
-msgid ""
-"An error occurred while creating the autostart desktop entry\n"
-"Please run from a terminal with the -v flag and try again."
-msgstr ""
-
-#: ../variety/VarietyWindow.py:3073
-msgid "No images"
-msgstr ""
-
-#: ../variety/VarietyWindow.py:3073
-msgid "There are no images in the slideshow folders"
-msgstr ""
-
-#: ../data/ui/AboutVarietyDialog.ui:9
+#: ../data/ui/AboutVarietyDialog.ui.h:1
 msgid "About Variety"
 msgstr ""
 
-#: ../data/ui/AboutVarietyDialog.ui:14
+#: ../data/ui/AboutVarietyDialog.ui.h:2
 msgid "Copyright (c) 2012-2020, Peter Levi, James Lu & Variety contributors"
 msgstr ""
 
-#: ../data/ui/AboutVarietyDialog.ui:15
+#: ../data/ui/AboutVarietyDialog.ui.h:3
 msgid "An automatic wallpaper changer, downloader and manager."
 msgstr ""
 
-#: ../data/ui/AboutVarietyDialog.ui:17
+#: ../data/ui/AboutVarietyDialog.ui.h:4
 msgid "https://peterlevi.com/variety"
 msgstr ""
 
-#: ../data/ui/AboutVarietyDialog.ui:18
+#: ../data/ui/AboutVarietyDialog.ui.h:5
 msgid ""
 "# Copyright (c) 2012-2020, Peter Levi, James Lu & Variety contributors\n"
 "# This program is free software: you can redistribute it and/or modify it\n"
@@ -945,90 +299,355 @@ msgid ""
 "# with this program.  If not, see <http://www.gnu.org/licenses/>.\n"
 msgstr ""
 
-#: ../data/ui/AddConfigurableDialog.ui:160
-msgid "Just a moment to check for images"
-msgstr ""
-
-#: ../data/ui/AddConfigurableDialog.ui:187 ../data/ui/AddFlickrDialog.ui:360
-msgid "  "
-msgstr ""
-
-#: ../data/ui/AddFlickrDialog.ui:9
+#: ../data/ui/AddFlickrDialog.ui.h:1
 msgid "Variety - add Flickr as an image source"
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:101
+#: ../data/ui/AddFlickrDialog.ui.h:2 ../variety/PreferencesVarietyDialog.py:435
+msgid "Flickr"
+msgstr ""
+
+#: ../data/ui/AddFlickrDialog.ui.h:3
 msgid ""
 "Please specify the <a href=\"http://flickr.com\">Flickr</a> search criteria. "
 "Photos that match all of the chosen criteria will be downloaded. Leave "
 "unneeded criteria empty."
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:124
-#: ../data/ui/PreferencesVarietyDialog.ui:1440
+#: ../data/ui/AddFlickrDialog.ui.h:4
+#: ../data/ui/PreferencesVarietyDialog.ui.h:62
 msgid "Tags: "
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:155
+#: ../data/ui/AddFlickrDialog.ui.h:5
 msgid ""
 "A comma-separated list of tags. A photo has to contain all of them "
 "simultaneosly in order to match.\n"
 "Example: yellow,car"
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:171
+#: ../data/ui/AddFlickrDialog.ui.h:7
 msgid "User: "
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:202
+#: ../data/ui/AddFlickrDialog.ui.h:8
 msgid ""
 "Please insert the URL to the user's photostream or to one of their photos.\n"
 "Example: <a href=\"http://www.flickr.com/photos/peter-levi/\">http://www."
 "flickr.com/photos/peter-levi/</a>"
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:218
+#: ../data/ui/AddFlickrDialog.ui.h:10
 msgid "Group: "
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:248
+#: ../data/ui/AddFlickrDialog.ui.h:11
 msgid ""
 "Please insert the group's URL.\n"
 "Example: <a href=\"http://www.flickr.com/groups/wallpapers/\">http://www."
 "flickr.com/groups/wallpapers/</a>"
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:264
+#: ../data/ui/AddFlickrDialog.ui.h:13
 msgid "Text:"
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:295
+#: ../data/ui/AddFlickrDialog.ui.h:14
 msgid ""
 "Free text search in photos' titles, descriptions and tags. Exclude terms by "
 "prepending them with -.\n"
 "Example: apple -pie"
 msgstr ""
 
-#: ../data/ui/AddFlickrDialog.ui:334
+#: ../data/ui/AddFlickrDialog.ui.h:16
 msgid "Just a moment to check this search"
 msgstr ""
 
-#: ../data/ui/EditFavoriteOperationsDialog.ui:8
-#: ../data/ui/EditFavoriteOperationsDialog.ui:91
+#: ../data/ui/AddFlickrDialog.ui.h:17 ../data/ui/AddWallhavenDialog.ui.h:7
+#: ../data/ui/AddConfigurableDialog.ui.h:2
+msgid "  "
+msgstr ""
+
+#: ../data/ui/AddWallhavenDialog.ui.h:1
+msgid "Instruction"
+msgstr ""
+
+#: ../data/ui/AddWallhavenDialog.ui.h:2
+msgid ""
+"To fetch <b>NSFW</b> images, you can provide your own <a href='https://"
+"wallhaven.cc/settings/account'>Wallhaven API key</a>. You need a free "
+"Wallhaven account, log in, go to <a href='https://wallhaven.cc/settings/"
+"account'>Account Settings</a>, find it under <b>API Key</b>. Without an API "
+"key, even if your search shows NSFW images in the browser, Variety will not "
+"be able to fetch them. Even with an API key, in order to fetch <b>NSFW</b> "
+"images, you need to provide a full search URL, not just keywords. \n"
+"\n"
+"<b>Note: This is a global setting which affects all Wallhaven sources</b>"
+msgstr ""
+
+#: ../data/ui/AddWallhavenDialog.ui.h:5
+msgid "API Key:"
+msgstr ""
+
+#: ../data/ui/AddWallhavenDialog.ui.h:6 ../data/ui/AddConfigurableDialog.ui.h:1
+msgid "Just a moment to check for images"
+msgstr ""
+
+#: ../variety/FolderChooser.py:67
+msgid "Choose a folder"
+msgstr ""
+
+#: ../variety/FolderChooser.py:70 ../variety/PreferencesVarietyDialog.py:615
+#: ../variety/PreferencesVarietyDialog.py:656
+msgid "Cancel"
+msgstr ""
+
+#: ../variety/FolderChooser.py:70
+msgid "OK"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashDownloader.py:30
+#: ../variety/Texts.py:46
+msgid "High-resolution photos from Unsplash.com"
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py:22
+#, python-format
+msgid "[GNOME/Mate/Cinnamon] %s"
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/GnomeDisplayModesPlugin.py:24
+msgid ""
+"Variety will instruct the desktop environment to use this mode when calling "
+"set_wallpaper, and will not itself scale the image, unless needed by other "
+"options, e.g. clock. "
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:84
+msgid "Configurable source for fetching photos from Unsplash.com"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:97
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:102
+#: ../variety/plugins/builtin/downloaders/WallhavenSource.py:76
+#: ../variety/AddFlickrDialog.py:148
+msgid "No images found"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:99
+msgid "We do not support this type of URL"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:104
+msgid "Oops, this didn't work. Is the remote service up?"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:111
+msgid ""
+"We use the <a href='https://unsplash.com'>Unsplash</a> API to fetch random "
+"images that match the given search term or URL. The Unsplash API is rate-"
+"limited, so Variety fetches images from Unsplash sources as a reduced rate.\n"
+"\n"
+"Please specify either a search keyword, or the URL of a search result, user, "
+"collection or topic.\n"
+"Example: <a href='https://unsplash.com/collections/3863203/desktop-"
+"wallpapers'>https://unsplash.com/collections/3863203/desktop-wallpapers</a>\n"
+"Example: <a href='https://unsplash.com/@pawel_czerwinski'>https://unsplash."
+"com/@pawel_czerwinski</a>\n"
+"Example: <a href='https://unsplash.com/t/wallpapers'>https://unsplash.com/t/"
+"wallpapers</a>"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:123
+msgid "Search keyword or URL: "
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/UnsplashConfigurableSource.py:126
+msgid "Fetch images from Unsplash.com for a given criteria"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/WallhavenSource.py:37
+msgid "Configurable source for fetching images from Wallhaven.cc"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/WallhavenSource.py:53
+msgid ""
+"<a href='http://wallhaven.cc'>Wallhaven.cc</a> provides a variety of image "
+"search options. Below you can specify keywords to search for, or visit <a "
+"href='http://wallhaven.cc'>Wallhaven.cc</a>, setup your search criteria "
+"there, ensure you like the results, and paste the full Wallhaven URL in the "
+"box.\n"
+"\n"
+"If you specify keywords, the most liked safe-for-work images that match all "
+"of the keywords will be used. \n"
+"\n"
+"If you specify a Wallhaven URL, please choose the sorting criteria carefully "
+"- Variety regularly requests images, but uses only images from the first "
+"several hundred returned. Random or Date will mean this image source will "
+"have a longer 'lifetime' till it is exhausted. Favorites will provide better "
+"images and Relevance will provide closer matches when searching for phrases "
+"or colors."
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/WallhavenSource.py:68
+msgid "Enter keywords or paste URL here: "
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/WallhavenSource.py:71
+msgid "Fetch images from Wallhaven.cc for a given criteria"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/WallhavenSource.py:78
+msgid "Got \"Unauthorized\" response. Invalid API key?"
+msgstr ""
+
+#: ../variety/plugins/builtin/quotes/UrbanDictionarySource.py:29
+msgid "Displays definitions from Urban Dictionary"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:35
+msgid "Configurable source for fetching images from ArtStation"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:48
+msgid ""
+"Enter the name of an artist or paste the full URL of their artstation page "
+"with .rss extenstion or without it. \n"
+"Example: You may specify simply 'leimin' or <a href='https://www.artstation."
+"com/leimin'>https://www.artstation.com/leimin</a>\n"
+"Example: Or direct it to the RSS: <a href='https://www.artstation.com/leimin."
+"rss'>https://www.artstation.com/leimin.rss</a>"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:57
+msgid "URL or name of an artist: "
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:60
+msgid "Fetch images from a given artist"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:68
+msgid "We cannot download individual artworks."
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:81
+msgid "This does not seem to be a valid ArtStation URL"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:87
+#: ../variety/plugins/builtin/downloaders/ArtStationSource.py:93
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:79
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:85
+msgid "We could not find any image submissions there."
+msgstr ""
+
+#: ../variety/ThumbsManager.py:41 ../data/ui/PreferencesVarietyDialog.ui.h:57
+msgid "Bottom"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:42
+msgid "Top"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:43
+msgid "Left"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:44 ../data/ui/PreferencesVarietyDialog.ui.h:51
+msgid "Right"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:117
+msgid "Position"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:121 ../data/ui/PreferencesVarietyDialog.ui.h:113
+msgid "Size"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:125
+msgid "Maximum Shown Images"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:139
+msgid "Show Containing Folder"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:152 ../variety/VarietyWindow.py:753
+msgid "Fetched: Show Origin"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:154 ../variety/VarietyWindow.py:757
+#: ../variety/VarietyWindow.py:879
+#, python-format
+msgid "View at %s"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:169 ../variety/indicator.py:168
+msgid "Set EXIF Rating"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:177 ../variety/VarietyWindow.py:722
+#: ../variety/indicator.py:90
+msgid "Copy to _Favorites"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:186 ../variety/VarietyWindow.py:723
+msgid "Move to _Favorites"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:197 ../variety/indicator.py:101
+msgid "Delete to _Trash"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:206 ../variety/indicator.py:147
+msgid "Where is it from?"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:220
+msgid "Close"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:240
+msgid "Could not set EXIF rating"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:260
+msgid "Unrated"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:267
+msgid "Rejected"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:380
+msgid "Variety History"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:382
+msgid "Variety Recent Downloads"
+msgstr ""
+
+#: ../variety/ThumbsManager.py:384
+msgid "Variety Images"
+msgstr ""
+
+#: ../data/ui/EditFavoriteOperationsDialog.ui.h:1
 msgid "Copy to Favorites vs. Move to Favorites"
 msgstr ""
 
-#: ../data/ui/EditFavoriteOperationsDialog.ui:24
+#: ../data/ui/EditFavoriteOperationsDialog.ui.h:2
 msgid "Reset to Default"
 msgstr ""
 
-#: ../data/ui/EditFavoriteOperationsDialog.ui:110
+#: ../data/ui/EditFavoriteOperationsDialog.ui.h:3
 msgid ""
 "Select whether your prefer 'Copy to Favorites' or 'Move to Favorites' in the "
 "menu depending on the image location:"
 msgstr ""
 
-#: ../data/ui/EditFavoriteOperationsDialog.ui:155
+#: ../data/ui/EditFavoriteOperationsDialog.ui.h:4
 msgid ""
 "Please enter one entry per line, each entry in the form <Folder>:<Copy, Move "
 "or Both>, where Folder can be Downloaded, Fetched, Others or a specific "
@@ -1045,413 +664,873 @@ msgid ""
 "\tOthers:Both"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:24
+#: ../variety/FlickrDownloader.py:45
+msgid "Images from Flickr"
+msgstr ""
+
+#: ../variety/QuotesEngine.py:248
+msgid "No suitable quote plugins"
+msgstr ""
+
+#: ../variety/QuotesEngine.py:250
+msgid ""
+"There are no quote plugins installed, enabled and applicable for the current "
+"settings"
+msgstr ""
+
+#: ../variety/QuotesEngine.py:267
+msgid "Could not fetch quotes"
+msgstr ""
+
+#: ../variety/QuotesEngine.py:268
+msgid "Quotes services may be down, we will continue trying"
+msgstr ""
+
+#: ../variety/QuotesEngine.py:272
+msgid "Could not find quotes"
+msgstr ""
+
+#: ../variety/QuotesEngine.py:273
+msgid "Maybe you are searching for something very obscure?"
+msgstr ""
+
+#: ../variety/Texts.py:21
+msgid "Keep original"
+msgstr ""
+
+#: ../variety/Texts.py:22
+msgid "Grayscale"
+msgstr ""
+
+#: ../variety/Texts.py:23
+msgid "Heavy blur"
+msgstr ""
+
+#: ../variety/Texts.py:24
+msgid "Soft blur"
+msgstr ""
+
+#: ../variety/Texts.py:25
+msgid "Oil painting"
+msgstr ""
+
+#: ../variety/Texts.py:26
+msgid "Pointilism"
+msgstr ""
+
+#: ../variety/Texts.py:27
+msgid "Pixellate"
+msgstr ""
+
+#: ../variety/Texts.py:31
+msgid "The Favorites folder"
+msgstr ""
+
+#: ../variety/Texts.py:32
+msgid "The Fetched folder"
+msgstr ""
+
+#: ../variety/Texts.py:35
+msgid ""
+"Recommended by Variety. Adapts to your taste as you mark images as favorite "
+"or trash."
+msgstr ""
+
+#: ../variety/Texts.py:39
+msgid ""
+"Latest favorites by the other users of Variety. [May contain NSFW images]"
+msgstr ""
+
+#: ../variety/Texts.py:41
+msgid "Random wallpapers from Desktoppr.co"
+msgstr ""
+
+#: ../variety/Texts.py:42
+msgid "NASA's Astronomy Picture of the Day"
+msgstr ""
+
+#: ../variety/Texts.py:43
+#: ../variety/plugins/builtin/downloaders/BingDownloader.py:30
+msgid "Bing Photo of the Day"
+msgstr ""
+
+#: ../variety/Texts.py:54
+msgid ""
+"You can change the wallpaper back and forth by scrolling the mouse wheel on "
+"top of the indicator icon."
+msgstr ""
+
+#: ../variety/Texts.py:57
+msgid ""
+"You can configure how the wallpaper scales, zooms or tiles directly from the "
+"Appearance/Background settings in your OS. Variety sets which image to show, "
+"but does not tell the OS how to draw it."
+msgstr ""
+
+#: ../variety/Texts.py:61
+#, python-brace-format
+msgid ""
+"If you want to run custom commands every time the wallpaper changes or if "
+"you use an alternative desktop environment, please edit the scripts in "
+"{PROFILE_PATH}scripts. There are examples there for various desktop "
+"environments."
+msgstr ""
+
+#: ../variety/Texts.py:64
+msgid ""
+"Variety can be controlled from the command line and you can use this to "
+"define keyboard shortcuts for the operations you use most often. Run "
+"\"variety --help\" to see all available commands."
+msgstr ""
+
+#: ../variety/Texts.py:67
+msgid ""
+"You can drop image links or files on the launcher icon to download them and "
+"use them as wallpapers. For quicker downloading from a specific site, you "
+"can also use clipboard monitoring (see \"Downloading\" tab)."
+msgstr ""
+
+#: ../variety/Texts.py:70
+msgid ""
+"Applying a heavy blurring filter is a great way to get abstract-looking and "
+"unobtrusive, yet colorful wallpapers, similar in spirit to the default one "
+"in Ubuntu."
+msgstr ""
+
+#: ../variety/Texts.py:73
+#, python-brace-format
+msgid ""
+"Adding your own custom filters is quite easy: open {PROFILE_PATH}variety."
+"conf in an editor and use the existing filters as an example. Every filter "
+"is just a line of options to be passed to ImageMagick's convert command."
+msgstr ""
+
+#: ../variety/Texts.py:76
+msgid ""
+"When you select an image source, its images are displayed in a window at the "
+"bottom of the screen. Click an image there to set is as wallpaper. Right-"
+"click to close the window, to modify its appearance or to perform file "
+"operations. You can select multiple image sources to create a \"merged\" "
+"thumbnail view of all of them. Please mind that thumbnail view is limited to "
+"several hundred randomly selected images."
+msgstr ""
+
+#: ../variety/Texts.py:79
+msgid ""
+"Variety's indicator icon is themeable - if you choose the \"Light\" option "
+"for the icon, Variety will first check if the current GTK theme has an icon "
+"named \"variety-indicator\" and will use it instead of the bundled light "
+"icon."
+msgstr ""
+
+#: ../variety/Texts.py:82
+#, python-brace-format
+msgid ""
+"When you choose to save quotes to Favorites, these are by default saved to "
+"{PROFILE_PATH}favorite_quotes.txt. This file is compatible with Variety's "
+"local files quote source. If you want to use it - copy it to ~/.config/"
+"variety/pluginconfig/quotes/ and enable the Local Files quote source. This "
+"file is also compatible with the Unix fortune utility."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:718 ../variety/VarietyWindow.py:895
+#: ../variety/VarietyWindow.py:2986
+msgid "Already in Favorites"
+msgstr ""
+
+#. both
+#: ../variety/VarietyWindow.py:731 ../data/ui/PreferencesVarietyDialog.ui.h:153
+#: ../variety/indicator.py:95
+msgid "Move to Favorites"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:755
+#, python-format
+msgid "Source: %s"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:821
+msgid "Unknown"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:843
+#, python-format
+msgid "Author: %s"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:866 ../variety/VarietyWindow.py:888
+#: ../variety/indicator.py:136 ../variety/indicator.py:200
+msgid "Pause on current"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:868 ../variety/VarietyWindow.py:890
+msgid "Resume regular changes"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:895 ../variety/indicator.py:206
+msgid "Save to Favorites"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:1044
+msgid "Filtering too strict?"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:1046
+msgid ""
+"Variety is finding too few images that match your image filtering criteria. "
+"Please check if the settings in \"Filtering\" are correct."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:1736
+msgid "Please add more image sources or wait for some downloads"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:1738
+msgid "Please add more image sources"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:1739
+msgid "No more wallpapers"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2010
+msgid "Current wallpaper is not in the image sources"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2043
+#, python-format
+msgid ""
+"Could not move to %s. You probably don't have permissions to move this file."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2050
+#, python-format
+msgid ""
+"Could not copy to %s. You probably don't have permissions to copy this file."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2075 ../variety/VarietyWindow.py:2098
+msgid "Cannot delete"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2076
+#, python-format
+msgid "You don't have permissions to delete %s to Trash."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2099
+msgid "Deleting to trash failed, check variety.log for more information."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2385
+msgid "Upgraded scripts"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2387
+msgid ""
+"If you had customized scripts for Variety, please see Preferences -> "
+"Changelog"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2438
+msgid ""
+"I will open an editor with the config file and apply the changes after you "
+"save and close the editor."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2584 ../variety/ImageFetcher.py:66
+#: ../variety/ImageFetcher.py:76 ../variety/ImageFetcher.py:83
+#: ../variety/ImageFetcher.py:117
+msgid "Not an image"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2590
+msgid "Added to queue"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2591 ../variety/VarietyWindow.py:2604
+msgid "Press Next to see it"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2603
+msgid "Fetched"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2654
+msgid "Unsupported source type"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2655 ../variety/VarietyWindow.py:2703
+msgid "Are you running the most recent version of Variety?"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2665
+msgid "New image source added"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2667
+msgid "Image source already exists, enabling it"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2693
+msgid "Fetched and applied"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2698
+msgid "It works!"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2698
+msgid "Yay, Variety links work. Great!"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2702
+msgid "Unsupported command"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2707
+msgid "Could not process the given variety:// URL"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:2708
+msgid "Run with logging enabled to see details"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3073
+msgid "Variety: New desktop entry"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3075
+msgid ""
+"We created a new desktop entry in ~/.local/share/applications to run Variety "
+"with profile \"{}\". Find it in the application launcher."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3100
+msgid "Variety: Created autostart desktop entry"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3102
+msgid ""
+"We created a new desktop entry in ~/.config/autostart. Variety should start "
+"automatically on next login."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3109
+msgid "Could not create autostart entry"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3111
+msgid ""
+"An error occurred while creating the autostart desktop entry\n"
+"Please run from a terminal with the -v flag and try again."
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3176
+msgid "No images"
+msgstr ""
+
+#: ../variety/VarietyWindow.py:3176
+msgid "There are no images in the slideshow folders"
+msgstr ""
+
+#: ../variety/ImageFetcher.py:62 ../variety/ImageFetcher.py:108
+msgid "Fetching"
+msgstr ""
+
+#. too small - delete and do not use
+#: ../variety/ImageFetcher.py:123
+msgid "Image too small, ignoring it"
+msgstr ""
+
+#: ../variety/ImageFetcher.py:148
+#, python-format
+msgid "Sorry, got %s error..."
+msgstr ""
+
+#: ../variety/ImageFetcher.py:149
+msgid "This means the link is no longer valid"
+msgstr ""
+
+#: ../variety/ImageFetcher.py:153
+msgid "Fetch failed for some reason"
+msgstr ""
+
+#: ../variety/ImageFetcher.py:155
+msgid ""
+"To get more information, please run Variety from terminal with -v option and "
+"retry the action"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/EarthviewDownloader.py:32
+msgid "Google Earth View Wallpapers"
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:61
+msgid "Smart: Variety picks best mode based on image size. Recommended."
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:73
+msgid "Zoom to fill screen"
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:75
+msgid ""
+"Image is zoomed in or out so that it fully fills your primary screen. Some "
+"parts of the image will be cut out if its resolution is different from the "
+"screen's. Slower than using native OS resizing options."
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:84
+msgid "Fit within screen, pad with black"
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:86
+msgid ""
+"Image is zoomed in or out so that it fully fits within your primary screen. "
+"The rest of the screen is filled with black. Slower than using native OS "
+"resizing options."
+msgstr ""
+
+#: ../variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py:95
+msgid "Fit within screen, pad with a blurred background. Slower."
+msgstr ""
+
+#: ../variety/plugins/builtin/quotes/FortuneSource.py:37
+msgid ""
+"Displays quotes using the UNIX fortune program. You may want to install "
+"additional fortune packs, e.g. fortunes-bofh-excuses."
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:1
 msgid "seconds"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:28
-#: ../data/ui/PreferencesVarietyDialog.ui:50
+#: ../data/ui/PreferencesVarietyDialog.ui.h:2
 msgid "minutes"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:32
-#: ../data/ui/PreferencesVarietyDialog.ui:54
+#: ../data/ui/PreferencesVarietyDialog.ui.h:3
 msgid "hours"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:36
-#: ../data/ui/PreferencesVarietyDialog.ui:58
+#: ../data/ui/PreferencesVarietyDialog.ui.h:4
 msgid "days"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:196
-#: ../data/ui/PreferencesVarietyDialog.ui:672
+#: ../data/ui/PreferencesVarietyDialog.ui.h:5
+#: ../variety/PreferencesVarietyDialog.py:91
+msgid "Variety Preferences"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:6
 msgid "General"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:209
+#: ../data/ui/PreferencesVarietyDialog.ui.h:7
 msgid "Start Variety when the computer starts"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:236
+#: ../data/ui/PreferencesVarietyDialog.ui.h:8
 msgid "Change wallpaper every "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:257
-#: ../data/ui/PreferencesVarietyDialog.ui:258
-#: ../data/ui/PreferencesVarietyDialog.ui:275
-#: ../data/ui/PreferencesVarietyDialog.ui:276
+#: ../data/ui/PreferencesVarietyDialog.ui.h:9
 msgid "Minimum interval is 5 seconds"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:303
+#: ../data/ui/PreferencesVarietyDialog.ui.h:10
 msgid "Change wallpaper on start"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:390
+#: ../data/ui/PreferencesVarietyDialog.ui.h:11
+msgid "Use Internet Access"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:12
+msgid ""
+"Turning off means Variety will not download new images or quotes from online "
+"sources, or initiate other internet connections."
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:13
+#: ../variety/PreferencesVarietyDialog.py:406
+#: ../variety/PreferencesVarietyDialog.py:622
+msgid "Images"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:14
 msgid "Enabled"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:401
+#: ../data/ui/PreferencesVarietyDialog.ui.h:15
 msgid "Type"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:412
+#: ../data/ui/PreferencesVarietyDialog.ui.h:16
 msgid "Location"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:448
+#: ../data/ui/PreferencesVarietyDialog.ui.h:17
 msgid "_Add..."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:454
-#: ../data/ui/PreferencesVarietyDialog.ui:455
+#: ../data/ui/PreferencesVarietyDialog.ui.h:18
 msgid "Add images, folders or online image sources"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:467
+#: ../data/ui/PreferencesVarietyDialog.ui.h:19
 msgid "_Open Folder"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:472
-#: ../data/ui/PreferencesVarietyDialog.ui:473
-#: ../data/ui/PreferencesVarietyDialog.ui:491
-#: ../data/ui/PreferencesVarietyDialog.ui:492
+#: ../data/ui/PreferencesVarietyDialog.ui.h:20
 msgid "Edit the selected source"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:486
+#: ../data/ui/PreferencesVarietyDialog.ui.h:21
 msgid "_Edit..."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:505
+#: ../data/ui/PreferencesVarietyDialog.ui.h:22
 msgid "_Remove..."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:511
-#: ../data/ui/PreferencesVarietyDialog.ui:512
+#: ../data/ui/PreferencesVarietyDialog.ui.h:23
 msgid "Remove selected image sources"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:525
+#: ../data/ui/PreferencesVarietyDialog.ui.h:24
 msgid "_Use"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:530
-#: ../data/ui/PreferencesVarietyDialog.ui:531
+#: ../data/ui/PreferencesVarietyDialog.ui.h:25
 msgid "Enable the selected sources and disable all others"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:582
+#: ../data/ui/PreferencesVarietyDialog.ui.h:26
 msgid "Favorites"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:606
+#: ../data/ui/PreferencesVarietyDialog.ui.h:27
 msgid "Copy favorite wallpapers to "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:691
-msgid "Filters"
+#: ../data/ui/PreferencesVarietyDialog.ui.h:28
+msgid "Alignment and scaling"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:716
+#: ../data/ui/PreferencesVarietyDialog.ui.h:29
+msgid "Auto-rotate the image according to EXIF data"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:30
+msgid "Display mode"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:31
+msgid "Description goes here "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:32
 msgid ""
-"Randomly apply these filters to the displayed wallpapers (thanks to the "
+"Experimental: Some options may not work well in all desktop environments or "
+"multi-monitor configurations."
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:33
+msgid "Effects"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:34
+msgid ""
+"Randomly apply these effects to the displayed wallpapers (thanks to the "
 "wonderful ImageMagick):"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:788
+#: ../data/ui/PreferencesVarietyDialog.ui.h:35
+msgid "Wallpaper"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:36
 msgid "Quotes"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:801
+#: ../data/ui/PreferencesVarietyDialog.ui.h:37
 msgid "Show random wise quotes on the desktop"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:840
-msgid "Text color: "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:38
+msgid "Change quote every "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:869
-msgid "Text font: "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:39
+msgid "Minimum interval is 10 seconds"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:913
-msgid "Backdrop color: "
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:941
-msgid "Backdrop opacity: "
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:955
-msgid " Transparent"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:986
-msgid "Opaque"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1004
-msgid "Draw a text shadow"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1028
-#: ../data/ui/PreferencesVarietyDialog.ui:1777
+#: ../data/ui/PreferencesVarietyDialog.ui.h:40
 msgid "Appearance"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1059
-msgid "Quotes area width: "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:41
+msgid "Text color: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1073
-msgid "Narrow "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:42
+msgid "Text font: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1104
-msgid "Wide"
+#: ../data/ui/PreferencesVarietyDialog.ui.h:43
+msgid "Draw a text shadow"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1128
-msgid "Horizontal position: "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:44
+msgid "Backdrop color: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1142
-msgid "Left "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:45
+msgid "Backdrop opacity: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1197
-msgid "Vertical position: "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:46
+msgid " Transparent"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1211
-msgid "Top "
+#: ../data/ui/PreferencesVarietyDialog.ui.h:47
+msgid "Opaque"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1264
+#: ../data/ui/PreferencesVarietyDialog.ui.h:48
 msgid "Placement"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1298
+#: ../data/ui/PreferencesVarietyDialog.ui.h:49
+msgid "Horizontal position: "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:50
+msgid "Left "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:52
+msgid "Quotes area width: "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:53
+msgid "Narrow "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:54
+msgid "Wide"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:55
+msgid "Vertical position: "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:56
+msgid "Top "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:58
+msgid "Sources and filtering"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:59
 msgid "Show quotes from these sources: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1372
+#: ../data/ui/PreferencesVarietyDialog.ui.h:60
 msgid ""
 "<small><a href='http://peterlevi.com/variety/wiki/Plugins'>More plugins</a></"
 "small>"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1391
+#: ../data/ui/PreferencesVarietyDialog.ui.h:61
 msgid "Show only these tags and authors. Leave empty to show random quotes."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1453
+#: ../data/ui/PreferencesVarietyDialog.ui.h:63
 msgid "Example: funny, inspirational"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1466
+#: ../data/ui/PreferencesVarietyDialog.ui.h:64
 msgid "Example: Albert Einstein, Voltaire"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1479
+#: ../data/ui/PreferencesVarietyDialog.ui.h:65
 msgid "Authors: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1500
-msgid "Sources and filtering"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1526
-msgid "Change quote every "
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1547
-#: ../data/ui/PreferencesVarietyDialog.ui:1548
-#: ../data/ui/PreferencesVarietyDialog.ui:1565
-#: ../data/ui/PreferencesVarietyDialog.ui:1566
-msgid "Minimum interval is 10 seconds"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1593
-msgid "Regular change"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1622
+#: ../data/ui/PreferencesVarietyDialog.ui.h:66
 msgid "Clock"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1635
+#: ../data/ui/PreferencesVarietyDialog.ui.h:67
 msgid ""
 "Show a nice big digital clock on the desktop, displaying the current time "
 "and date"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1640
+#: ../data/ui/PreferencesVarietyDialog.ui.h:68
 msgid ""
 "To configure the clock's appearance edit the clock_filter property in "
 "Variety's settings file (~/.config/variety/variety.conf). Use the comments "
 "in ~/.config/variety/variety_latest_default.conf as a guide."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1676
+#: ../data/ui/PreferencesVarietyDialog.ui.h:69
 msgid "Clock font: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1719
+#: ../data/ui/PreferencesVarietyDialog.ui.h:70
 msgid "Date font: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1760
+#: ../data/ui/PreferencesVarietyDialog.ui.h:71
 msgid ""
 "These don't work? <a href=\"https://answers.launchpad.net/variety/"
-"+faq/2138\">Read here</a>. How to further configure the clock? <a href="
-"\"http://peterlevi.com/variety/2012/11/configuring-the-clock/\">Read here</"
-"a>."
+"+faq/2138\">Read here</a>. How to further configure the clock? <a "
+"href=\"http://peterlevi.com/variety/2012/11/configuring-the-clock/\">Read "
+"here</a>."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1803
-msgid "Effects"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:1831
+#: ../data/ui/PreferencesVarietyDialog.ui.h:72
 msgid "Images for slideshow"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1853
+#: ../data/ui/PreferencesVarietyDialog.ui.h:73
 msgid "Favorite images"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1872
+#: ../data/ui/PreferencesVarietyDialog.ui.h:74
 msgid "Images in all enabled image sources"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1890
+#: ../data/ui/PreferencesVarietyDialog.ui.h:75
 msgid "All images in the Downloads folder"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1915
+#: ../data/ui/PreferencesVarietyDialog.ui.h:76
 msgid "Custom folder (includes images in subfolders) "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1977
+#: ../data/ui/PreferencesVarietyDialog.ui.h:77
 msgid "Order of images in slideshow "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1991
+#: ../data/ui/PreferencesVarietyDialog.ui.h:78
 msgid "Random"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1992
+#: ../data/ui/PreferencesVarietyDialog.ui.h:79
 msgid "By name, A to Z"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1993
+#: ../data/ui/PreferencesVarietyDialog.ui.h:80
 msgid "By name, Z to A"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1994
+#: ../data/ui/PreferencesVarietyDialog.ui.h:81
 msgid "By date, oldest first"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:1995
+#: ../data/ui/PreferencesVarietyDialog.ui.h:82
 msgid "By date, newest first"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2027
+#: ../data/ui/PreferencesVarietyDialog.ui.h:83
 msgid "Screen"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2052
+#: ../data/ui/PreferencesVarietyDialog.ui.h:84
 msgid "Run on monitor"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2088
+#: ../data/ui/PreferencesVarietyDialog.ui.h:85
 msgid "Window mode for the slideshow "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2102
+#: ../data/ui/PreferencesVarietyDialog.ui.h:86
 msgid "Fullscreen"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2103
+#: ../data/ui/PreferencesVarietyDialog.ui.h:87
 msgid "Desktop (stays below other windows)"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2104
+#: ../data/ui/PreferencesVarietyDialog.ui.h:88
 msgid "Maximized window"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2105
+#: ../data/ui/PreferencesVarietyDialog.ui.h:89
 msgid "Normal window"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2150
+#: ../data/ui/PreferencesVarietyDialog.ui.h:90
 msgid "Dynamics"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2177
+#: ../data/ui/PreferencesVarietyDialog.ui.h:91
 msgid "Interval between image changes "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2206
+#: ../data/ui/PreferencesVarietyDialog.ui.h:92
 msgid " seconds"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2235
+#: ../data/ui/PreferencesVarietyDialog.ui.h:93
 msgid "Quick fade "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2265
+#: ../data/ui/PreferencesVarietyDialog.ui.h:94
 msgid "Slow fade"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2289
+#: ../data/ui/PreferencesVarietyDialog.ui.h:95
 msgid "Less zoom"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2318
+#: ../data/ui/PreferencesVarietyDialog.ui.h:96
 msgid "More zoom"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2342
+#: ../data/ui/PreferencesVarietyDialog.ui.h:97
 msgid "Less pan"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2371
+#: ../data/ui/PreferencesVarietyDialog.ui.h:98
 msgid "More pan"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2395
+#: ../data/ui/PreferencesVarietyDialog.ui.h:99
 msgid "Reset to defaults"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2429
+#: ../data/ui/PreferencesVarietyDialog.ui.h:100
 msgid "Changes on this page take effect after the slideshow is restarted"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2442
+#: ../data/ui/PreferencesVarietyDialog.ui.h:101
 msgid "Start slideshow now"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2470
+#: ../data/ui/PreferencesVarietyDialog.ui.h:102
 msgid "Slideshow"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2497
+#: ../data/ui/PreferencesVarietyDialog.ui.h:103
 msgid "Fetch folder"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2520
+#: ../data/ui/PreferencesVarietyDialog.ui.h:104
 msgid "Save manually downloaded wallpapers to "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2574
+#: ../data/ui/PreferencesVarietyDialog.ui.h:105
 msgid "Drag and drop"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2594
+#: ../data/ui/PreferencesVarietyDialog.ui.h:106
 msgid ""
 "Variety's icon in the launcher serves as a drop target. Drop any image URL "
 "or file on it and it will be saved to your fetch folder. You can then press "
@@ -1460,210 +1539,216 @@ msgid ""
 "to lock it there for easy drag-and-drop access."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2628
+#: ../data/ui/PreferencesVarietyDialog.ui.h:108
 msgid "Clipboard monitoring"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2641
+#: ../data/ui/PreferencesVarietyDialog.ui.h:109
 msgid "Monitor clipboard for image URLs and fetch them"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2663
+#: ../data/ui/PreferencesVarietyDialog.ui.h:110
 msgid "But fetch only when the URL host is one of these:"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2728
-msgid "Manual downloading"
+#: ../data/ui/PreferencesVarietyDialog.ui.h:111
+msgid "Downloading"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2748
+#: ../data/ui/PreferencesVarietyDialog.ui.h:112
 msgid "When possible use images that:"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2784
+#: ../data/ui/PreferencesVarietyDialog.ui.h:114
 msgid "Have landscape orientation"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2809
+#: ../data/ui/PreferencesVarietyDialog.ui.h:115
 msgid "Are big at least "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2831
+#: ../data/ui/PreferencesVarietyDialog.ui.h:116
 msgid "50"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2832
+#: ../data/ui/PreferencesVarietyDialog.ui.h:117
 msgid "80"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2833
+#: ../data/ui/PreferencesVarietyDialog.ui.h:118
 msgid "100"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2848
+#: ../data/ui/PreferencesVarietyDialog.ui.h:120
+#, no-c-format
 msgid "% of the screen resolution"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2882
+#: ../data/ui/PreferencesVarietyDialog.ui.h:121
 msgid "Color"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2901
+#: ../data/ui/PreferencesVarietyDialog.ui.h:122
 msgid "Are dark or light:"
 msgstr ""
 
-#. Color option - images that are dark or light
-#: ../data/ui/PreferencesVarietyDialog.ui:2923
+#: ../data/ui/PreferencesVarietyDialog.ui.h:123
 msgctxt "Color option - images that are dark or light"
 msgid "Dark"
 msgstr ""
 
-#. Color option - images that are dark or light
-#: ../data/ui/PreferencesVarietyDialog.ui:2924
+#: ../data/ui/PreferencesVarietyDialog.ui.h:124
 msgctxt "Color option - images that are dark or light"
 msgid "Light"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2949
+#: ../data/ui/PreferencesVarietyDialog.ui.h:125
 msgid "Contain this color: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:2985
+#: ../data/ui/PreferencesVarietyDialog.ui.h:126
 msgid "(Takes effect after some initial searching)"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3024
+#: ../data/ui/PreferencesVarietyDialog.ui.h:127
 msgid "Rating"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3041
+#: ../data/ui/PreferencesVarietyDialog.ui.h:128
 msgid "Have EXIF rating at least "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3064
+#: ../data/ui/PreferencesVarietyDialog.ui.h:129
 msgid "1"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3065
+#: ../data/ui/PreferencesVarietyDialog.ui.h:130
 msgid "2"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3066
+#: ../data/ui/PreferencesVarietyDialog.ui.h:131
 msgid "3"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3067
+#: ../data/ui/PreferencesVarietyDialog.ui.h:132
 msgid "4"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3068
+#: ../data/ui/PreferencesVarietyDialog.ui.h:133
 msgid "5"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3104
-msgid "Color and size"
+#: ../data/ui/PreferencesVarietyDialog.ui.h:134
+msgid "Name"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3131
+#: ../data/ui/PreferencesVarietyDialog.ui.h:135
+msgid "Matches RegEx: "
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:136
+msgid "Filtering"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:137
 msgid "Indicator Icon"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3154
+#: ../data/ui/PreferencesVarietyDialog.ui.h:138
 msgid "Indicator icon:"
 msgstr ""
 
-#. Icon option
-#: ../data/ui/PreferencesVarietyDialog.ui:3170
+#: ../data/ui/PreferencesVarietyDialog.ui.h:139
 msgctxt "Icon option"
 msgid "Light"
 msgstr ""
 
-#. Icon option
-#: ../data/ui/PreferencesVarietyDialog.ui:3171
+#: ../data/ui/PreferencesVarietyDialog.ui.h:140
 msgctxt "Icon option"
 msgid "Dark"
 msgstr ""
 
-#. Icon option
-#: ../data/ui/PreferencesVarietyDialog.ui:3172
+#: ../data/ui/PreferencesVarietyDialog.ui.h:141
 msgctxt "Icon option"
 msgid "Number 1"
 msgstr ""
 
-#. Icon option
-#: ../data/ui/PreferencesVarietyDialog.ui:3173
+#: ../data/ui/PreferencesVarietyDialog.ui.h:142
 msgctxt "Icon option"
 msgid "Number 2"
 msgstr ""
 
-#. Icon option
-#: ../data/ui/PreferencesVarietyDialog.ui:3174
+#: ../data/ui/PreferencesVarietyDialog.ui.h:143
 msgctxt "Icon option"
 msgid "Number 3"
 msgstr ""
 
-#. Icon option
-#: ../data/ui/PreferencesVarietyDialog.ui:3175
+#: ../data/ui/PreferencesVarietyDialog.ui.h:144
 msgctxt "Icon option"
 msgid "Number 4"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3176
+#: ../data/ui/PreferencesVarietyDialog.ui.h:145
 msgctxt "Icon option"
 msgid "Use current wallpaper"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3177
+#: ../data/ui/PreferencesVarietyDialog.ui.h:146
 msgctxt "Icon option"
 msgid "Custom image..."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3178
+#: ../data/ui/PreferencesVarietyDialog.ui.h:147
 msgctxt "Icon option"
 msgid "None"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3195
+#: ../data/ui/PreferencesVarietyDialog.ui.h:148
 msgid "Select an icon"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3219
+#: ../data/ui/PreferencesVarietyDialog.ui.h:149
 msgid ""
 "When the icon is hidden, Variety can be controlled from the command line, or "
 "from the launcher quicklist. Run \"variety --help\" to see all available "
 "commands."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3249
+#: ../data/ui/PreferencesVarietyDialog.ui.h:150
 msgid "Favorites Operations"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3272
+#: ../data/ui/PreferencesVarietyDialog.ui.h:151
 msgid "Favorites operations to show in main menu:"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3288
+#: ../data/ui/PreferencesVarietyDialog.ui.h:152
 msgid "Copy to Favorites"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3290
+#: ../data/ui/PreferencesVarietyDialog.ui.h:154
 msgid "Both Copy and Move"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3291
+#: ../data/ui/PreferencesVarietyDialog.ui.h:155
 msgid "Depends on folder..."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3348
+#: ../data/ui/PreferencesVarietyDialog.ui.h:156
+#: ../variety/PreferencesVarietyDialog.py:810
+msgid "Edit..."
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:157
 msgid "Login Screen Support"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3370
+#: ../data/ui/PreferencesVarietyDialog.ui.h:158
 msgid ""
 "Make sure the wallpapers set by Variety will be used on the login screen"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3394
+#: ../data/ui/PreferencesVarietyDialog.ui.h:159
 msgid ""
 "<b>Privacy warning:</b> To show your wallpaper LightDM needs read "
 "permissions over the image. With this option on, Variety will copy the "
@@ -1673,74 +1758,79 @@ msgid ""
 "multiuser systems."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3416
+#: ../data/ui/PreferencesVarietyDialog.ui.h:160
 msgid "Copy wallpaper image files to this folder: "
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3443
+#: ../data/ui/PreferencesVarietyDialog.ui.h:161
 msgid "Reset to default"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3458
+#: ../data/ui/PreferencesVarietyDialog.ui.h:162
 msgid "Still doesn't work?"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3488
+#: ../data/ui/PreferencesVarietyDialog.ui.h:163
 msgid ""
 "It seems your home folder is encrypted, so using folders inside it will not "
 "work."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3509
+#: ../data/ui/PreferencesVarietyDialog.ui.h:164
 msgid "You don't have write permissions for this folder."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3526
+#: ../data/ui/PreferencesVarietyDialog.ui.h:165
 msgid "Permissions do not allow LightDM to read files from this folder."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3543
+#: ../data/ui/PreferencesVarietyDialog.ui.h:166
 msgid ""
 "Variety can adjust the permissions, but you will have to provide superuser "
 "privileges."
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3600
+#: ../data/ui/PreferencesVarietyDialog.ui.h:167
 msgid "Customize"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3619
-#: ../data/ui/PreferencesVarietyDialog.ui:3865
+#: ../data/ui/PreferencesVarietyDialog.ui.h:168
 msgid "Tips and tricks"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3667
-msgid "Recent changes"
-msgstr ""
-
-#: ../data/ui/PreferencesVarietyDialog.ui:3719
+#: ../data/ui/PreferencesVarietyDialog.ui.h:169
 msgid "Visit website"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3754
+#: ../data/ui/PreferencesVarietyDialog.ui.h:170
 msgid "Report a bug or request a feature"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3788
+#: ../data/ui/PreferencesVarietyDialog.ui.h:171
 msgid "Send feedback"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3821
-#: ../data/ui/PreferencesVarietyDialog.ui:3885
+#: ../data/ui/PreferencesVarietyDialog.ui.h:172
 msgid "Donate to Variety"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3833
-#: ../data/ui/PreferencesVarietyDialog.ui:3919
+#: ../data/ui/PreferencesVarietyDialog.ui.h:173
 msgid "Donate via PayPal"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3903
+#: ../data/ui/PreferencesVarietyDialog.ui.h:174
+msgid "Tips"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:175
+msgid "Recent changes"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:176
+msgid "Changelog"
+msgstr ""
+
+#: ../data/ui/PreferencesVarietyDialog.ui.h:177
 msgid ""
 "I am developing Variety in my spare time, which usually means the late hours "
 "after my kids go to bed. Any amount you donate will be appreciated. It will "
@@ -1751,32 +1841,268 @@ msgid ""
 "Peter Levi"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3951
+#: ../data/ui/PreferencesVarietyDialog.ui.h:181
 msgid "To donate in Bitcoin, please send to this wallet:"
 msgstr ""
 
-#: ../data/ui/PreferencesVarietyDialog.ui:3964
+#: ../data/ui/PreferencesVarietyDialog.ui.h:182
 msgid "1EHtkck9pw2Ry4NP6Es8rAXWEeADLdkqcu"
 msgstr ""
 
-#: ../data/ui/PrivacyNoticeDialog.ui:14
+#: ../data/ui/PreferencesVarietyDialog.ui.h:183 ../variety/indicator.py:304
+msgid "Donate"
+msgstr ""
+
+#: ../variety.desktop.in.h:1
+msgid "Variety"
+msgstr ""
+
+#: ../variety.desktop.in.h:2
+msgid "Variety Wallpaper Changer"
+msgstr ""
+
+#: ../variety.desktop.in.h:3
+msgid "Next"
+msgstr ""
+
+#: ../variety.desktop.in.h:4
+msgid "Previous"
+msgstr ""
+
+#: ../variety.desktop.in.h:5
+msgid "Pause / Resume"
+msgstr ""
+
+#: ../variety.desktop.in.h:6
+msgid "History"
+msgstr ""
+
+#: ../variety.desktop.in.h:7
+msgid "Preferences"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/NationalGeographicDownloader.py:29
+msgid "National Geographic's photo of the day"
+msgstr ""
+
+#: ../variety/indicator.py:63 ../variety/indicator.py:110
+#: ../variety/indicator.py:179
+msgid "_Next"
+msgstr ""
+
+#: ../variety/indicator.py:68 ../variety/indicator.py:115
+#: ../variety/indicator.py:184
+msgid "_Previous"
+msgstr ""
+
+#: ../variety/indicator.py:75
+msgid "Current desktop wallpaper"
+msgstr ""
+
+#: ../variety/indicator.py:79
+msgid "Show origin"
+msgstr ""
+
+#: ../variety/indicator.py:120 ../variety/indicator.py:189
+msgid "_Next, skipping forward history"
+msgstr ""
+
+#: ../variety/indicator.py:130
+msgid ""
+"Tip: Scroll wheel over icon\n"
+"for Next and Previous"
+msgstr ""
+
+#: ../variety/indicator.py:140
+msgid "_Image"
+msgstr ""
+
+#: ../variety/indicator.py:151
+msgid "Show without effects"
+msgstr ""
+
+#: ../variety/indicator.py:161
+msgid "Google Image Search"
+msgstr ""
+
+#: ../variety/indicator.py:211
+msgid "View Favorites..."
+msgstr ""
+
+#: ../variety/indicator.py:218
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: ../variety/indicator.py:228
+msgid "Google Quote"
+msgstr ""
+
+#: ../variety/indicator.py:233
+msgid "Google Author"
+msgstr ""
+
+#: ../variety/indicator.py:240 ../variety/indicator.py:296
+msgid "Preferences..."
+msgstr ""
+
+#: ../variety/indicator.py:250
+msgid "Turn off"
+msgstr ""
+
+#: ../variety/indicator.py:255
+msgid "_Quote"
+msgstr ""
+
+#: ../variety/indicator.py:262
+msgid "_History"
+msgstr ""
+
+#: ../variety/indicator.py:268
+msgid "_Wallpaper Selector"
+msgstr ""
+
+#: ../variety/indicator.py:276
+msgid "Recent _Downloads"
+msgstr ""
+
+#: ../variety/indicator.py:284
+msgid "Start Slideshow"
+msgstr ""
+
+#: ../variety/indicator.py:300
+msgid "About"
+msgstr ""
+
+#: ../variety/indicator.py:308
+msgid "Quit"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/APODDownloader.py:29
+msgid "NASA Astro Pic of the Day"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:89
+msgid " (Profile: {})"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:258
+msgid "All"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:406
+msgid "Add individual wallpaper images"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:409
+msgid "Folders"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:410
+msgid "Searched recursively for up to 10000 images, shown in random order"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:417
+msgid "Sequential Albums (order by filename)"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:418
+msgid "Searched recursively for images, shown in sequence (by filename)"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:425
+msgid "Sequential Albums (order by date)"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:426
+msgid "Searched recursively for images, shown in sequence (by file date)"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:435
+msgid "Fetch images from Flickr"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:488
+msgid "Remove the source, keep the files"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:490
+msgid "Remove the sources, keep the files"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:501
+msgid "Remove the source and delete the downloaded files"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:503
+msgid "Remove the sources and delete the downloaded files"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:538
+#, python-format
+msgid ""
+"Using this source requires wallpaper changing enabled at intervals of %d "
+"minutes or less. Settings were adjusted automatically."
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:612
+msgid "Add Images"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:615
+#: ../variety/PreferencesVarietyDialog.py:656
+msgid "Add"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:640
+msgid ""
+"Add Folders - Only add the root folders, subfolders are searched recursively"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:644
+msgid ""
+"Add Sequential Albums (ordered by filename). Subfolders are searched "
+"recursively."
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:648
+msgid ""
+"Add Sequential Albums (ordered by date). Subfolders are searched recursively."
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:812
+msgid "Open Folder"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:818
+msgid "View Image"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:1216
+#: ../variety/PreferencesVarietyDialog.py:1223
+msgid "No write permissions"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:1298
+msgid "Could not adjust permissions"
+msgstr ""
+
+#: ../variety/PreferencesVarietyDialog.py:1299
+#, python-format
+msgid ""
+"You may try manually running this command:\n"
+"sudo chmod %s \"%s\""
+msgstr ""
+
+#: ../data/ui/PrivacyNoticeDialog.ui.h:1
 msgid "Variety - Privacy Notice"
 msgstr ""
 
-#: ../data/ui/PrivacyNoticeDialog.ui:45
-msgid "Reject and Quit"
-msgstr ""
-
-#: ../data/ui/PrivacyNoticeDialog.ui:58
-msgid "Accept and Continue"
-msgstr ""
-
-#: ../data/ui/PrivacyNoticeDialog.ui:97
+#: ../data/ui/PrivacyNoticeDialog.ui.h:2
 msgid "<span font=\"15\" weight=\"bold\">Privacy Notice</span>"
 msgstr ""
 
 #. Main text for the Privacy Notice dialog
-#: ../data/ui/PrivacyNoticeDialog.ui:124
+#: ../data/ui/PrivacyNoticeDialog.ui.h:4
 msgid ""
 "Before we start, here are some things you need to be aware of and agree to:\n"
 "\n"
@@ -1789,8 +2115,8 @@ msgid ""
 "Variety downloads images from the internet. Web servers it downloads from "
 "may collect information about your device, like IP address. Variety does not "
 "send any personally identifiable information. By using Variety, you accept "
-"its use of internet connectivity. Note that all online image sources can be "
-"disabled. \n"
+"its use of internet connectivity. <b>Note that all internet connectivity can "
+"be disabled.</b> \n"
 "\n"
 "<b>Variety fetches and applies rate limiting settings defined by the "
 "development team.</b> This may affect the rate at which it downloads new "
@@ -1804,15 +2130,80 @@ msgid ""
 "and report when users download and view images from Unsplash."
 msgstr ""
 
-#: ../data/ui/WelcomeDialog.ui:13 ../data/ui/WelcomeDialog.ui:76
+#: ../data/ui/PrivacyNoticeDialog.ui.h:13
+msgid ""
+"<b>Use Internet Access:</b>\n"
+"<i>Can be changed later in Preferences</i>"
+msgstr ""
+
+#: ../data/ui/PrivacyNoticeDialog.ui.h:15
+msgid ""
+"Enabling internet access is highly recommended. Without it, many of the "
+"functions Variety provides are disabled. \n"
+"\n"
+"You can change this setting later in Preferences."
+msgstr ""
+
+#: ../data/ui/PrivacyNoticeDialog.ui.h:18
+msgid "Reject and Quit"
+msgstr ""
+
+#: ../data/ui/PrivacyNoticeDialog.ui.h:19
+msgid "Accept and Continue"
+msgstr ""
+
+#: ../variety/__init__.py:121
+msgid "Terminating signal received, quitting..."
+msgstr ""
+
+#: ../variety/__init__.py:195
+msgid ""
+"Variety is already running. Sending the command to the running instance."
+msgstr ""
+
+#: ../variety/plugins/builtin/quotes/QuotationsPageSource.py:34
+msgid "Fetches quotes from TheQuotationsPage.com"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:35
+msgid "Configurable source for fetching images from Reddit"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:48
+msgid ""
+"Enter the name of a subreddit or paste the full URL of a subreddit or a <a "
+"href='http://reddit.com'>Reddit</a> user. You may specify sort order and "
+"time period if you wish. Variety will use posts to direct images or to Imgur "
+"pages within the first 100 submissions returned by Reddit.\n"
+"\n"
+"Example: You may specify simply 'comics' or <a href='http://www.reddit.com/r/"
+"comics'>http://www.reddit.com/r/comics</a>\n"
+"Example: Top posts from the month: <a href='http://www.reddit.com/r/comics/"
+"top/?sort=top&amp;t=month'>http://www.reddit.com/r/comics/top/?sort=top&amp;"
+"t=month</a>"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:59
+msgid "URL or name of a subreddit: "
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:62
+msgid "Fetch images from a given subreddit or user"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/RedditSource.py:73
+msgid "This does not seem to be a valid Reddit URL"
+msgstr ""
+
+#: ../data/ui/WelcomeDialog.ui.h:1
 msgid "Welcome to Variety!"
 msgstr ""
 
-#: ../data/ui/WelcomeDialog.ui:38
+#: ../data/ui/WelcomeDialog.ui.h:2
 msgid "Continue"
 msgstr ""
 
-#: ../data/ui/WelcomeDialog.ui:94
+#: ../data/ui/WelcomeDialog.ui.h:3
 msgid ""
 "Variety is an automatic wallpaper changer. It rotates your desktop wallpaper "
 "on a regular basis using local images or images downloaded from various "
@@ -1820,14 +2211,44 @@ msgid ""
 "this icon in your system tray:"
 msgstr ""
 
-#: ../data/ui/WelcomeDialog.ui:124
+#: ../data/ui/WelcomeDialog.ui.h:4
 msgid ""
 "Variety is open-source software, created by Peter Levi, a software developer "
 "from Bulgaria. If you like it, please <a href=\"http://peterlevi.com/variety/"
 "donate/\">donate</a>."
 msgstr ""
 
-#: ../data/ui/WelcomeDialog.ui:143
+#: ../data/ui/WelcomeDialog.ui.h:5
 msgid ""
 "Now please take some time to set your preferences on the following screens."
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/MediaRSSSource.py:33
+msgid "Configurable source for fetching images from MediaRSS feeds"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/MediaRSSSource.py:46
+msgid ""
+"Please paste the URL of the Media RSS feed below. Please note that only "
+"Media RSS feeds are supported, not arbitrary RSS feeds. Media RSS feeds "
+"contain media:content tags linking directly to the actual image content. "
+"Some examples of sites that provide Media RSS feeds are: <a href='https://"
+"picasaweb.google.com/'>Picasa</a>, <a href='http://www.deviantart."
+"com'>deviantART</a>, <a href='http://www.smugmug.com/browse/'>SmugMug</a>, "
+"<a href='http://www.flickr.com'>Flickr</a>, <a href='http://interfacelift."
+"com'>InterfaceLIFT</a>."
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/MediaRSSSource.py:58
+msgid "Paste the URL of the Media RSS feed here: "
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/MediaRSSSource.py:61
+msgid "Fetch images from a MediaRSS feed"
+msgstr ""
+
+#: ../variety/plugins/builtin/downloaders/MediaRSSSource.py:68
+msgid ""
+"This does not seem to be a valid Media RSS feed URL or there is no content "
+"there."
 msgstr ""

--- a/variety/Options.py
+++ b/variety/Options.py
@@ -253,6 +253,16 @@ class Options:
                 pass
 
             try:
+                self.name_regex_enabled = config["name_regex_enabled"].lower() in TRUTH_VALUES
+            except Exception:
+                pass
+
+            try:
+                self.name_regex = config["name_regex"]
+            except Exception:
+                pass
+
+            try:
                 self.smart_notice_shown = config["smart_notice_shown"].lower() in TRUTH_VALUES
             except Exception:
                 pass
@@ -664,6 +674,8 @@ class Options:
         self.lightness_mode = Options.LightnessMode.DARK
         self.min_rating_enabled = False
         self.min_rating = 4
+        self.name_regex_enabled = False
+        self.name_regex = "*"
 
         self.smart_notice_shown = False
         self.smart_register_shown = False
@@ -783,6 +795,8 @@ class Options:
             config["lightness_mode"] = str(self.lightness_mode)
             config["min_rating_enabled"] = str(self.min_rating_enabled)
             config["min_rating"] = str(self.min_rating)
+            config["name_regex_enabled"] = str(self.name_regex_enabled)
+            config["name_regex"] = str(self.name_regex)
 
             config["smart_notice_shown"] = str(self.smart_notice_shown)
             config["smart_register_shown"] = str(self.smart_register_shown)

--- a/variety/Options.py
+++ b/variety/Options.py
@@ -675,7 +675,7 @@ class Options:
         self.min_rating_enabled = False
         self.min_rating = 4
         self.name_regex_enabled = False
-        self.name_regex = "*"
+        self.name_regex = ".*"
 
         self.smart_notice_shown = False
         self.smart_register_shown = False

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -207,6 +207,8 @@ class PreferencesVarietyDialog(PreferencesDialog):
             )
             self.ui.min_rating_enabled.set_active(self.options.min_rating_enabled)
             self.ui.min_rating.set_active(self.options.min_rating - 1)
+            self.ui.name_regex_enabled.set_active(self.options.name_regex_enabled)
+            self.ui.name_regex.set_text(self.options.name_regex)
             self.ui.clock_enabled.set_active(self.options.clock_enabled)
             self.ui.clock_font.set_font_name(self.options.clock_font)
             self.ui.clock_date_font.set_font_name(self.options.clock_date_font)
@@ -351,6 +353,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
             self.on_min_size_enabled_toggled()
             self.on_lightness_enabled_toggled()
             self.on_min_rating_enabled_toggled()
+            self.on_name_regex_enabled_toggled()
             self.on_copyto_enabled_toggled()
             self.on_quotes_change_enabled_toggled()
             self.on_icon_changed()
@@ -1056,6 +1059,12 @@ class PreferencesVarietyDialog(PreferencesDialog):
             except Exception:
                 pass
 
+            self.options.name_regex_enabled = self.ui.name_regex_enabled.get_active()
+            try:
+                self.options.name_regex = self.ui.name_regex.get_text()
+            except Exception:
+                pass
+
             self.options.clock_enabled = self.ui.clock_enabled.get_active()
             self.options.clock_font = self.ui.clock_font.get_font_name()
             self.options.clock_date_font = self.ui.clock_date_font.get_font_name()
@@ -1181,6 +1190,9 @@ class PreferencesVarietyDialog(PreferencesDialog):
 
     def on_min_rating_enabled_toggled(self, widget=None):
         self.ui.min_rating.set_sensitive(self.ui.min_rating_enabled.get_active())
+
+    def on_name_regex_enabled_toggled(self, widget=None):
+        self.ui.name_regex.set_sensitive(self.ui.name_regex_enabled.get_active())
 
     def on_lightness_enabled_toggled(self, widget=None):
         self.ui.lightness.set_sensitive(self.ui.lightness_enabled.get_active())

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -583,6 +583,11 @@ class VarietyWindow(Gtk.Window):
             or self.previous_options.min_rating != self.options.min_rating
         ):
             return True
+        if (
+            self.previous_options.name_regex_enabled != self.options.name_regex_enabled
+            or self.previous_options.name_regex != self.options.name_regex
+        ):
+            return True
         return False
 
     def size_options_changed(self):
@@ -1846,6 +1851,10 @@ class VarietyWindow(Gtk.Window):
             if self.options.min_rating_enabled:
                 rating = Util.get_rating(img)
                 if rating is None or rating <= 0 or rating < self.options.min_rating:
+                    return False
+
+            if self.options.name_regex_enabled:
+                if re.fullmatch(self.options.name_regex, os.path.basename(img)) is None:
                     return False
 
             if self.options.use_landscape_enabled or self.options.min_size_enabled:


### PR DESCRIPTION
Hello,

I implemented a simple name regex check to allow filtering what images are shown.
It is integrated in the preferences dialog under the Filtering category.
This is useful mostly when using a local folder source.

I ran the tests prior to this pull request, all pass except _TestNationalGeographicDownloader.TestNationalGeographicDownloader_, which is not related to my modifications.
I tested a local build on my own machine (Manjaro Gnome), all works as expected.

Please let me know if I should modify anything for this to be merged in the master branch, I would be happy to help.

Best regards,
Francois
