### PR TITLE
Add avif image format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To install Variety from source, you will need Git, Python 3.5+ and [distutils-ex
 - *Optional*: feh or nitrogen: used by default to set wallpapers on i3, openbox, and other WMs
 - *Optional*: libayatana-indicator (for AppIndicator support)
 - *Optional*: for tray icon support on GNOME, the [GNOME AppIndicator extension](https://github.com/ubuntu/gnome-shell-extension-appindicator)
+- *Optional*: libavif-gdk-pixbuf (for avif format support)
 
 See `debian/control` for an equivalent list of runtime dependencies on Debian/Ubuntu.
 

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,8 @@ Depends: gir1.2-gdkpixbuf-2.0,
          ${python3:Depends}
 Recommends: gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1,
             python3-httplib2,
-            fortune-mod
+            fortune-mod,
+            libavif-gdk-pixbuf
 Suggests: feh | nitrogen,
           gnome-shell-extension-appindicator | gnome-shell-extension-top-icons-plus
 Description: Wallpaper changer, downloader and manager

--- a/variety/ImageFetcher.py
+++ b/variety/ImageFetcher.py
@@ -37,7 +37,7 @@ class ImageFetcher:
                         if h and p.netloc.lower().find(h) >= 0:
                             return True
                 else:
-                    return p.path.lower().endswith((".jpg", ".jpeg", ".png", ".tiff"))
+                    return p.path.lower().endswith((".jpg", ".jpeg", ".png", ".tiff", ".avif"))
                     # skip gif - they are usually small images
             return False
         except Exception:

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -374,7 +374,7 @@ class Util:
 
         if not check_contents:
             return filename.lower().endswith(
-                (".jpg", ".jpeg", ".gif", ".png", ".tiff", ".svg", ".bmp")
+                (".jpg", ".jpeg", ".gif", ".png", ".tiff", ".svg", ".bmp", ".avif")
             )
         else:
             format, image_width, image_height = GdkPixbuf.Pixbuf.get_file_info(filename)


### PR DESCRIPTION
Unsplash start using avif image format now, varity cannot fetch avif nor preview/set avif image as background. 

To support avif, varity should allow `.avif` file extension and install `libavif-gdk-pixbuf` to decode.