### PR TITLE
switch from qdbus to dbus-send for setting KDE wallpaper

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -126,19 +126,11 @@ fi
 # and KDE will refresh it
 # On Plasma 5.7 and above, the wallpaper choosing is automatic.
 if [ "${KDE_FULL_SESSION}" == "true" ]; then
-    # Plasma 5.7 introduced a new feature to set the wallpaper via a qdbus script:
+    # Plasma 5.7 introduced a new feature to set the wallpaper via a dbus script:
     # https://github.com/KDE/plasma-workspace/commit/903cbfd7e267a4812a6ec222eb7e1b5dd775686f
     if [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" == '5' ]]; then
 
-        # Try to find the Qt 5 version of qdbus. For systems using qtchooser, the binary name is 'qdbus'
-        # and the Qt version can be selected via the QT_SELECT environment variable.
-        if command -v qdbus-qt5 &>/dev/null; then
-            qdbus_command=qdbus-qt5
-        else
-            qdbus_command=qdbus
-        fi
-
-        QT_SELECT=5 $qdbus_command org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "
+        dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"
         var allDesktops = desktops();
         for (i=0; i < allDesktops.length; i++) {
             d = allDesktops[i];
@@ -147,17 +139,17 @@ if [ "${KDE_FULL_SESSION}" == "true" ]; then
             d.writeConfig('Image', 'file://""$WP""')
         }
         "
-        # Reuse the exit code from qdbus
-        qdbus_exitcode="$?"
+        # Reuse the exit code from dbus
+        dbus_exitcode="$?"
 
-        if [[ "$qdbus_exitcode" -ne 0 ]]; then
+        if [[ "$dbus_exitcode" -ne 0 ]]; then
             # If the script fails, show a notification.
             kdialog --title "Variety: cannot change Plasma wallpaper" --passivepopup "Could not change the Plasma 5 wallpaper; \
                 make sure that you're using Plasma 5.7+ and have widgets unlocked.\n----\n \
                 Due to Plasma limitations, external programs cannot automatically change the wallpaper when the widgets are locked.\n \
                 See https://git.io/vprpM for more information." --icon variety 10  # Final number is the length of the popup
         fi
-        exit "$qdbus_exitcode"
+        exit "$dbus_exitcode"
 
     else
         WALLDIR="$(xdg-user-dir PICTURES)/variety-wallpaper"


### PR DESCRIPTION
Several distributions do not pull in `qt5-tools` or whatever package contains `qdbus` with a KDE installation. It is a safer assumption that `dbus-send` will be available as it is part of the `dbus` (or equivalent) package that is required for KDE to run.