### PR TITLE
Variety can't find metadata files because they get mislabled on downloaded

### DIFF
--- a/variety/plugins/downloaders/DefaultDownloader.py
+++ b/variety/plugins/downloaders/DefaultDownloader.py
@@ -248,6 +248,9 @@ class DefaultDownloader(Downloader, metaclass=abc.ABCMeta):
             Util.safe_unlink(local_filepath_partial)
             return None
 
+        # file rename is an atomic operation, so we should never end up with partial downloads
+        os.rename(local_filepath_partial, local_filepath)
+
         metadata = {
             "sourceType": source_type,
             "sourceName": source_name,
@@ -256,9 +259,7 @@ class DefaultDownloader(Downloader, metaclass=abc.ABCMeta):
             "imageURL": image_url,
         }
         metadata.update(extra_metadata or {})
-        Util.write_metadata(local_filepath_partial, metadata)
+        Util.write_metadata(local_filepath, metadata)
 
-        # file rename is an atomic operation, so we should never end up with partial downloads
-        os.rename(local_filepath_partial, local_filepath)
         logger.info(lambda: "Download complete")
         return local_filepath


### PR DESCRIPTION
I noticed Variety would name image metadata files with the image's partial filename causing Variety to fail to find them later. So I thought the best solution is to rename the image to it's proper one before writing a metadata. I also had some code accommodating for this bug by checking if a 'partial.metadata.json' equivalent file exists in `Util.read_metadata`, but I didn't commit it because I was unsure if you'd prefer people just manually rename their metadata files.