### PR TITLE
Fix hyprland stop working with somthing else then swaybg

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -227,8 +227,8 @@ if [[ " ${SIMPLE_WMS[*]} " = *" $XDG_CURRENT_DESKTOP "* || " ${SIMPLE_WMS[*]} " 
         nitrogen --set-zoom-fill --save "$WP" 2> /dev/null
     fi
 fi
-
-if [[ -n $SWAYSOCK || $XDG_CURRENT_DESKTOP == "Hyprland" ]]; then
+PID=`pidof swaybg`
+if [[ -n $PID ]]; then
     # If swaybg is available, use it as prevents system freeze.
     # See https://github.com/swaywm/sway/issues/5606
     if command -v "swaybg" >/dev/null 2>&1; then

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -234,7 +234,6 @@ if [[ -n $PID ]]; then
     if command -v "swaybg" >/dev/null 2>&1; then
         # Grey background flicker is prevented by killing old swaybg process after new one.
         # See https://github.com/swaywm/swaybg/issues/17#issuecomment-851680720
-        PID=`pidof swaybg`
         swaybg -i "$WP" -m fill &
         if [ ! -z "$PID" ]; then
             sleep 1


### PR DESCRIPTION
variety was getting stuck because instead of supporting a bg manager it supported an display manager.

In wayland most of the bg manager are "stand alone" (they still requre a DM so not rly) app and should be detect instead of a DM, otherwise it can make variety hang because its looking for an app not installed.

PATCH UNTESTED FOR SWAYBG (but it should work)