### PR TITLE
Add support for setting the wallpaper in  Plasma 6

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -128,16 +128,22 @@ fi
 if [ "${KDE_FULL_SESSION}" == "true" ]; then
     # Plasma 5.7 introduced a new feature to set the wallpaper via a dbus script:
     # https://github.com/KDE/plasma-workspace/commit/903cbfd7e267a4812a6ec222eb7e1b5dd775686f
-    if [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" == '5' ]]; then
-        dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"
+    plasma_qdbus_script="
         let allDesktops = desktops();
         for (let d of allDesktops) {
             if (d.wallpaperPlugin == 'org.kde.image') {
                 d.currentConfigGroup = Array('Wallpaper', 'org.kde.image', 'General');
-                d.writeConfig('Image', 'file://""$WP""')
+                d.writeConfig('Image', 'file://""$WP""');
             }
         }
-        "
+    "
+    if [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" == '6' ]]; then
+        dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script"
+        # Reuse the exit code from dbus
+        exit "$?"
+
+    elif [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" == '5' ]]; then
+        dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script"
         # Reuse the exit code from dbus
         dbus_exitcode="$?"
 

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -137,17 +137,12 @@ if [ "${KDE_FULL_SESSION}" == "true" ]; then
             }
         }
     "
-    if [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" == '6' ]]; then
-        dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script"
-        # Reuse the exit code from dbus
-        exit "$?"
-
-    elif [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" == '5' ]]; then
+    if [[ -n "${KDE_SESSION_VERSION}" && "${KDE_SESSION_VERSION}" -ge '5' ]]; then
         dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script"
         # Reuse the exit code from dbus
         dbus_exitcode="$?"
 
-        if [[ "$dbus_exitcode" -ne 0 ]]; then
+        if [[ "$dbus_exitcode" -ne 0 && "${KDE_SESSION_VERSION}" -eq '5' ]]; then
             # If the script fails, show a notification.
             kdialog --title "Variety: cannot change Plasma wallpaper" --passivepopup "Could not change the Plasma 5 wallpaper; \
                 make sure that you're using Plasma 5.7+ and have widgets unlocked.\n----\n \


### PR DESCRIPTION
This is basically just adding a check that understands the value of  "6" from `$KDE_SESSION_VERSION` and (in the case of Plasma 6) does not take dbus send failure to mean that widgets are locked, as that is no longer a thing that happens in Plasma (since at least Plasma 5.20).