### PR TITLE
set_wallpaper: missing fi on killing swaybg

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -239,6 +239,7 @@ if command -v "swaybg" >/dev/null 2>&1; then
     if [ ! -z "$PID" ]; then
         sleep 1
         kill $PID 2>/dev/null
+    fi
 else
     swaymsg output "*" bg "$WP" fill 2> /dev/null
 fi


### PR DESCRIPTION
I have been unable to use it on my sway DE but after putting the missing fi, it's now working. I don't know if it still has missing parts or syntax missing on it though as it's not properly highlighting the set_wallpaper file on my editor, but otherwise it now works.