### PR TITLE
Add 'Auto' option to icon and set depending on dark mode system pref

### DIFF
--- a/variety/Options.py
+++ b/variety/Options.py
@@ -195,7 +195,7 @@ class Options:
 
             try:
                 icon = config["icon"]
-                if icon in ["Light", "Dark", "Current", "1", "2", "3", "4", "None"] or (
+                if icon in ["Light", "Dark", "Auto", "Current", "1", "2", "3", "4", "None"] or (
                     os.access(icon, os.R_OK) and Util.is_image(icon)
                 ):
                     self.icon = icon

--- a/variety/PreferDarkThemeListener.py
+++ b/variety/PreferDarkThemeListener.py
@@ -1,0 +1,39 @@
+from gi.repository import Gtk
+from typing import Callable
+
+
+PREFER_DARK_THEME_PROPERTY = "gtk-application-prefer-dark-theme"
+
+
+class PreferDarkThemeListener:
+    def __init__(self) -> None:
+        self.settings: Gtk.Settings = Gtk.Settings.get_default()
+        self.callbacks: list[Callable[..., None]] = []
+        if self.settings:
+            self.settings.connect(
+                f"notify::{PREFER_DARK_THEME_PROPERTY}",
+                self._on_theme_changed,
+            )
+        self._notify_current_mode()
+
+    def _on_theme_changed(self, settings: Gtk.Settings, param: str) -> None:
+        self._notify_current_mode()
+
+    def _notify_current_mode(self) -> None:
+        for callback in self.callbacks:
+            callback(prefers_dark_mode=self.prefers_dark_mode)
+
+    @property
+    def prefers_dark_mode(self) -> bool:
+        return bool(self.settings.get_property(PREFER_DARK_THEME_PROPERTY))
+
+    def register_callback(self, callback: Callable[[bool], None]) -> None:
+        """
+        Register a callback to be invoked when the dark/light mode changes.
+
+        The callback will receive a single positional argument indicating
+        whether dark mode is enabled (True) or light mode (False).
+        """
+        if callback not in self.callbacks:
+            self.callbacks.append(callback)
+            callback(self.prefers_dark_mode)

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -166,6 +166,8 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 self.ui.icon.set_active(6)
             elif self.options.icon == "None":
                 self.ui.icon.set_active(8)
+            elif self.options.icon == "Auto":
+                self.ui.icon.set_active(9)
             else:
                 self.ui.icon.set_active(7)
                 self.ui.icon_chooser.set_filename(self.options.icon)
@@ -1007,6 +1009,8 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 self.options.icon = "Current"
             elif self.ui.icon.get_active() == 8:
                 self.options.icon = "None"
+            elif self.ui.icon.get_active() == 9:
+                self.options.icon = "Auto"
             elif self.ui.icon.get_active() == 7:
                 file = self.ui.icon_chooser.get_filename()
                 if file and os.access(file, os.R_OK):

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -38,6 +38,7 @@ from variety.DominantColors import DominantColors
 from variety.FlickrDownloader import FlickrDownloader
 from variety.ImageFetcher import ImageFetcher
 from variety.Options import Options
+from variety.PreferDarkThemeListener import PreferDarkThemeListener
 from variety.plugins.downloaders.ConfigurableImageSource import ConfigurableImageSource
 from variety.plugins.downloaders.DefaultDownloader import SAFE_MODE_BLACKLIST
 from variety.plugins.downloaders.ImageSource import ImageSource
@@ -107,6 +108,7 @@ class VarietyWindow(Gtk.Window):
         self.about = None
         self.preferences_dialog = None
         self.ind = None
+        self.prefer_dark_theme_listener = PreferDarkThemeListener()
 
         try:
             if Gio.SettingsSchemaSource.get_default().lookup("org.gnome.desktop.background", True):
@@ -2549,6 +2551,8 @@ class VarietyWindow(Gtk.Window):
 
             if self.options.icon == "Current":
                 self.ind.set_icon(self.current)
+            elif self.options.icon == "Auto":
+                pass # Let the listener set it
             else:
                 self.ind.set_icon(self.options.icon)
         else:

--- a/variety/indicator.py
+++ b/variety/indicator.py
@@ -21,6 +21,7 @@ import os
 
 from gi.repository import Gtk  # pylint: disable=E0611
 
+from variety.PreferDarkThemeListener import PreferDarkThemeListener
 from variety.Util import Util, _
 from variety_lib import varietyconfig
 
@@ -55,6 +56,7 @@ class Indicator:
         self.parent = window
         self.create_menu(window)
         self.create_indicator(window)
+        self.create_prefer_dark_mode_callback(window.prefer_dark_mode_listener)
 
     def create_menu(self, window):
         self.menu = Gtk.Menu()
@@ -348,6 +350,14 @@ class Indicator:
             self.status_icon.connect("activate", left_click_event)
             self.status_icon.connect("popup-menu", right_click_event)
             self.status_icon.connect("scroll-event", on_indicator_scroll_status_icon)
+
+    def create_prefer_dark_mode_callback(self, listener: PreferDarkThemeListener) -> None:
+        def set_auto_icon(prefers_dark_mode: bool) -> None:
+            if self.parent.options.icon == "Auto":
+                self.set_icon("Dark" if prefers_dark_mode else "Light")
+
+        listener.register_callback(set_auto_icon)
+
 
     def set_visible(self, visible):
         self.visible = visible


### PR DESCRIPTION
This PR is a draft to add a `PreferDarkModeListener` to Variety that can have callbacks registered to it in order to notify parts of the app of whether the user prefers dark mode or light mode at an OS level.

It is currently only being used to set the icon to Dark or Light automatically. But it could be used to choose wallpapers of a certain tone if the user wants that.

:warning: I have not tested this PR yet and am posting it just to gauge interest. I will see if it works and productize it if people want this.

Would fix: https://github.com/varietywalls/variety/issues/722