### PR TITLE
Removing tiny.cc link for security.

### DIFF
--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -89,7 +89,7 @@ OUTDATED_MSG = "This version of Variety is outdated and unsupported. Please upgr
 class VarietyWindow(Gtk.Window):
     __gtype_name__ = "VarietyWindow"
 
-    SERVERSIDE_OPTIONS_URL = "http://tiny.cc/variety-options-063"
+    SERVERSIDE_OPTIONS_URL = "https://gist.githubusercontent.com/peterlevi/a7d1dbf3a4e76e15760a/raw/fab10d0ce5cfe66377e7c650be56edb497aabbd4/variety_server_options.json"
 
     # How many unseen_downloads max to for every downloader.
     MAX_UNSEEN_PER_DOWNLOADER = 10


### PR DESCRIPTION
The tiny.cc link is causing security alerts(ET INFO URL Shortener Service Domain in DNS Lookup (tiny .cc)) in network security monitoring tools and has a very low score in VirusTotal due to the number of phishing and scams associated with the site. I recommend not using link shorteners if at all possible as over time they can expire, change operators, backends, or shutdown and leaves the link vulnerable to hijacking.

Thanks for all the work done here! Been a user for 10+ years, keep up the great work.