### PR TITLE
wf/fix-gexiv2-api: Handle different GExiv2.Metadata constructor api

### DIFF
--- a/variety/Util.py
+++ b/variety/Util.py
@@ -170,7 +170,12 @@ class VarietyMetadata(GExiv2.Metadata):
     }
 
     def __init__(self, path):
-        super(VarietyMetadata, self).__init__(path=path)
+        try:
+            super(VarietyMetadata, self).__init__(path=path)
+        except TypeError:
+            super(VarietyMetadata, self).__init__()
+            self.open_path(path)
+
         self.register_xmp_namespace("https://launchpad.net/variety/", "variety")
 
     def __getitem__(self, key):


### PR DESCRIPTION
What

- Extend Utils.py to handle different GExiv2.Metadata constructor apis

Why

- Path is optional in the constructor in later versions

AC

- Validated this in my local setup