### PR TITLE
add basic support for COSMIC DE (Pop!OS) - fixes #714

### DIFF
--- a/data/scripts/get_wallpaper
+++ b/data/scripts/get_wallpaper
@@ -47,6 +47,10 @@ elif [ "$XDG_CURRENT_DESKTOP" == "Trinity" ]; then
         # The "1" refers to the virtual desktop number
         dcop kdesktop KBackgroundIface currentWallpaper 1 2> /dev/null
 
+# Cosmic
+elif [ "$XDG_CURRENT_DESKTOP" == "COSMIC" ]; then
+        grep -oP '(?<=source: Path\(")(.+)(?="\))' ~/.config/cosmic/com.system76.CosmicBackground/v1/all
+
 # All above fails => fallback to the Gnome 3 way
 else
         gsettings get org.gnome.desktop.background picture-uri

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -281,6 +281,10 @@ elif [ "$DE" == "awesome" ]; then
     # As such, the theme's wallpaper will briefly appear before being replaced with Variety's wallpaper.
     echo "for s in screen do require(\"gears\").wallpaper.maximized(\"$1\", s) end" | awesome-client
 
+if [[ "$XDG_CURRENT_DESKTOP" == "COSMIC" ]]; then
+    sed -r --in-place 's,source: Path\(".+"\),source: Path("'"$3"'"),gm' ~/.config/cosmic/com.system76.CosmicBackground/v1/all
+fi
+
 else
     # For simple WMs, use either feh or nitrogen
     # TODO: These should take the scaling parameter $4 into account and use other options than --bg-fill


### PR DESCRIPTION
Adds support for the COSMIC DE as reported in #714  by adjusting the `get_wallpaper` and `set_wallpaper` scripts.

I tested that switching the image works.