### PR TITLE
Add option --meta

### DIFF
--- a/variety/VarietyOptionParser.py
+++ b/variety/VarietyOptionParser.py
@@ -108,6 +108,15 @@ To set a specific wallpaper: %prog --set /some/local/image.jpg
     )
 
     parser.add_option(
+        "--meta",
+        action="store_true",
+        dest="show_meta",
+        help=_(
+            "Print the current wallpaper metadata. Used only when the application is already running."
+        ),
+    )
+
+    parser.add_option(
         "--set",
         "--set-wallpaper",
         action="store",

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -2538,6 +2538,9 @@ class VarietyWindow(Gtk.Window):
 
             GObject.timeout_add(3000 if initial_run else 1, _process_command)
 
+            if options.show_meta:
+                return str(Util.read_metadata(self.current))
+
             return self.current if options.show_current else ""
         except Exception:
             logger.exception(lambda: "Could not process passed command")


### PR DESCRIPTION
Add a command line option (--meta) to get (or display) metadata associated with the current wallpaper.