### PR TITLE
Fix kill command syntax in set_wallpaper script

### DIFF
--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -245,8 +245,8 @@ elif [ "$DE" == "sway" ]; then
         swaybg -i "$WP" -m fill &
         if [ -n "$PID" ]; then
             sleep 1
-            read -a PID <<< "$PID"
-            for each_pid in "${PID[@]}; do
+            read -r -a PID <<< "$PID"
+            for each_pid in "${PID[@]}"; do
                 kill "$each_pid" 2>/dev/null
             done
         fi


### PR DESCRIPTION
`kill` was failing in cases when multiple `swaybg` instances were running simultaneously, because it was receiving a string of PIDs as a single argument. Removing the double quotes makes it effectively end any and all `swaybg` processes. Running processes were accumulating due to this very fault, making it a chinken-and-egg problem. Solved, anyway.