### PR TITLE
Implemented --show-image-origin CLI option.

### DIFF
--- a/variety/VarietyOptionParser.py
+++ b/variety/VarietyOptionParser.py
@@ -160,6 +160,15 @@ To set a specific wallpaper: %prog --set /some/local/image.jpg
     )
 
     parser.add_option(
+        "--image-origin",
+        "--show-image-origin",
+        "--show-origin",
+        action="store_true",
+        dest="showorigin",
+        help=_("Open current wallpaper origin page."),
+    )
+
+    parser.add_option(
         "--pause", action="store_true", dest="pause", help=_("Pause on current image")
     )
 

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -2495,6 +2495,8 @@ class VarietyWindow(Gtk.Window):
                         self.copy_to_favorites()
                     elif options.movefavorite:
                         self.move_to_favorites()
+                    elif options.showorigin:
+                        self.on_show_origin()
 
                 if options.set_wallpaper:
                     self.set_wallpaper(options.set_wallpaper)


### PR DESCRIPTION
I wanted an option to launch on_show_origin() from CLI. Scenario: I use Indicator Icon set to None, but wanted to set a key bind for quick launching the image origin website.
