### PR TITLE
Fix: re-Add support for Budgie DE after change of XDG_CURRENT_DESKTOP=Budgie

### DIFF
--- a/data/scripts/get_wallpaper
+++ b/data/scripts/get_wallpaper
@@ -7,7 +7,7 @@
 desktop="$DESKTOP_SESSION"
 
 # Gnome 3, Unity:
-if [ "$desktop" == "ubuntu" ] || [ "$XDG_CURRENT_DESKTOP" == "Unity" ]; then
+if [ "$desktop" == "ubuntu" ] || [ "$XDG_CURRENT_DESKTOP" == "Unity" ] || [ "$XDG_CURRENT_DESKTOP" == "Budgie" ]; then
         gsettings get org.gnome.desktop.background picture-uri
 
 # XFCE

--- a/data/scripts/set_wallpaper
+++ b/data/scripts/set_wallpaper
@@ -41,6 +41,7 @@ detect_desktop() {
         case "${XDG_CURRENT_DESKTOP,,}" in
         *"gnome"*) echo "gnome" ;;
         *"unity"*) echo "unity" ;;
+        *"budgie"*) echo "budgie" ;;
         *"kde"*) echo "kde" ;;
         *"xfce"*) echo "xfce" ;;
         *"lxde"*) echo "lxde" ;;
@@ -173,7 +174,7 @@ elif [ "$DE" == "kde" ]; then
     fi
     exit "$dbus_exitcode"
 
-elif [ "$DE" == "gnome" ] || [ "$DE" == "unity" ]; then
+elif [ "$DE" == "gnome" ] || [ "$DE" == "unity" ] || [ "$DE" == "budgie" ]; then
     # Gnome 3, Unity
     gsettings set org.gnome.desktop.background picture-uri "file://$WP" 2>/dev/null
     gsettings set org.gnome.desktop.background picture-uri-dark "file://$WP" 2>/dev/null


### PR DESCRIPTION
Recently, Budgie DE changed it's XDG_CURRENT_DESKTOP from Budgie:GNOME to Budgie.
This lead to variety not switching wallpapers anymore in Budgie.
Until now, there was no explicit support for Budgie DE. Variety worked in Budgie, because due to XDG_CURRENT_DESKTOP = Budgie:GNOME, variety treated Budgie as GNOME. This works, because Budgie is based on GNOME(though they are in process of moving apart).
My changes introduce Budgie support and makes again Budgie be treated as GNOME.
With those changes, variety regains ability to set wallpapers in Budgie.

Fixes #806 
Fixes #798 