### PR TITLE
Make changing lock screen background an option

### DIFF
--- a/variety/Options.py
+++ b/variety/Options.py
@@ -108,12 +108,22 @@ class Options:
                 pass
 
             try:
+                self.change_lock_screen = config["change_lock_screen"].lower() in TRUTH_VALUES
+            except Exception:
+                pass
+
+            try:
                 self.set_wallpaper_script = os.path.expanduser(config["set_wallpaper_script"])
             except Exception:
                 pass
 
             try:
                 self.get_wallpaper_script = os.path.expanduser(config["get_wallpaper_script"])
+            except Exception:
+                pass
+
+            try:
+                self.set_lock_screen_script = os.path.expanduser(config["set_lock_screen_script"])
             except Exception:
                 pass
 
@@ -632,9 +642,11 @@ class Options:
         self.change_interval = 300
         self.internet_enabled = True
         self.safe_mode = False
+        self.change_lock_screen = False
 
         self.set_wallpaper_script = os.path.join(get_profile_path(), "scripts", "set_wallpaper")
         self.get_wallpaper_script = os.path.join(get_profile_path(), "scripts", "get_wallpaper")
+        self.set_lock_screen_script = os.path.join(get_profile_path(), "scripts", "set_lock_screen")
 
         self.download_folder = os.path.join(get_profile_path(), "Downloaded")
         self.download_preference_ratio = 0.9
@@ -748,6 +760,7 @@ class Options:
             config["change_interval"] = str(self.change_interval)
             config["internet_enabled"] = str(self.internet_enabled)
             config["safe_mode"] = str(self.safe_mode)
+            config["change_lock_screen"] = str(self.change_lock_screen)
 
             config["set_wallpaper_script"] = Util.collapseuser(self.set_wallpaper_script)
             config["get_wallpaper_script"] = Util.collapseuser(self.get_wallpaper_script)

--- a/variety/PreferencesVarietyDialog.py
+++ b/variety/PreferencesVarietyDialog.py
@@ -180,6 +180,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
 
             self.favorites_operations = self.options.favorites_operations
 
+            self.ui.change_lock_screen_box.set_active(self.options.change_lock_screen)
             self.ui.copyto_enabled.set_active(self.options.copyto_enabled)
             self.copyto_chooser.set_folder(self.parent.get_actual_copyto_folder())
 
@@ -1020,6 +1021,7 @@ class PreferencesVarietyDialog(PreferencesDialog):
                 pass
 
             self.options.copyto_enabled = self.ui.copyto_enabled.get_active()
+            self.options.change_lock_screen = self.ui.change_lock_screen_box.get_active()
             copyto = os.path.normpath(self.copyto_chooser.get_folder())
             if copyto == os.path.normpath(self.parent.get_actual_copyto_folder("Default")):
                 self.options.copyto_folder = "Default"

--- a/variety/data/scripts/set_lock_screen
+++ b/variety/data/scripts/set_lock_screen
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# This script is run by Variety to change lock screen backgrounds, when that option is enabled.
+# The parameters are the same as set_wallpaper.
+WP=$1
+
+detect_desktop() {
+    if [ -n "$XDG_CURRENT_DESKTOP" ]; then
+        case "${XDG_CURRENT_DESKTOP,,}" in
+        *"gnome"*) echo "gnome" ;;
+        *"unity"*) echo "unity" ;;
+        *"budgie"*) echo "budgie" ;;
+        *"kde"*) echo "kde" ;;
+        esac
+        return
+    fi
+    echo "unknown"
+}
+
+DE=$(detect_desktop)
+
+if [ "$DE" == "kde" ]; then
+    kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group org.kde.image --group General --key Image "$WP"
+
+elif [ "$DE" == "gnome" ] || [ "$DE" == "unity" ] || [ "$DE" == "budgie" ]; then
+    # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch
+    gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2>/dev/null
+    if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
+        gsettings set org.gnome.desktop.screensaver picture-options "$4"
+    fi
+    if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
+        gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
+    fi
+else
+    echo "Unsupported desktop for automatic lock screen changing"
+    exit 1
+fi
+
+exit 0

--- a/variety/data/scripts/set_wallpaper
+++ b/variety/data/scripts/set_wallpaper
@@ -162,10 +162,6 @@ elif [ "$DE" == "kde" ]; then
     "
     dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script"
     dbus_exitcode="$?"
-    if [[ "$dbus_exitcode" -eq 0 && "${KDE_SESSION_VERSION}" -eq '6' ]]; then
-        # Update KDE lock screen background
-        kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group org.kde.image --group General --key Image "$WP"
-    fi
     if [[ "$dbus_exitcode" -ne 0 && "${KDE_SESSION_VERSION}" -eq '5' ]]; then
         kdialog --title "Variety: cannot change Plasma wallpaper" --passivepopup "Could not change the Plasma 5 wallpaper; \
             make sure that you're using Plasma 5.7+ and have widgets unlocked.\n----\n \
@@ -183,14 +179,6 @@ elif [ "$DE" == "gnome" ] || [ "$DE" == "unity" ] || [ "$DE" == "budgie" ]; then
     fi
     if [ "$(gsettings get org.gnome.desktop.background picture-options)" == "'none'" ]; then
         gsettings set org.gnome.desktop.background picture-options 'zoom'
-    fi
-    # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch
-    gsettings set org.gnome.desktop.screensaver picture-uri "file://$WP" 2>/dev/null
-    if [[ "$4" =~ ^(wallpaper|centered|scaled|stretched|zoom|spanned)$ ]]; then
-        gsettings set org.gnome.desktop.screensaver picture-options "$4"
-    fi
-    if [ "$(gsettings get org.gnome.desktop.screensaver picture-options)" == "'none'" ]; then
-        gsettings set org.gnome.desktop.screensaver picture-options 'zoom'
     fi
 
 elif [ "$DE" == "deepin" ]; then

--- a/variety/data/ui/PreferencesVarietyDialog.ui
+++ b/variety/data/ui/PreferencesVarietyDialog.ui
@@ -3606,7 +3606,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="lightdm_box">
+                  <object class="GtkBox" id="login_screen_support_box">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="valign">start</property>
@@ -3640,6 +3640,24 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                         <property name="hexpand">True</property>
                         <property name="orientation">vertical</property>
                         <child>
+                          <object class="GtkCheckButton" id="change_lock_screen_box">
+                            <property name="label" translatable="yes">Change lock screen background automatically</property>
+                            <property name="use-action-appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin-top">7</property>
+                            <property name="xalign">0</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkCheckButton" id="copyto_enabled">
                             <property name="label" translatable="yes">Copy wallpapers to a static location (for programs like LightDM that require a static path)</property>
                             <property name="use-action-appearance">False</property>
@@ -3652,24 +3670,6 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                             <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="delayed_apply" swapped="no"/>
                             <signal name="toggled" handler="on_copyto_enabled_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label19">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="margin-top">7</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Privacy warning:&lt;/b&gt; To show your wallpaper in a display manager, it may need read permissions to the image. With this option on, Variety will copy the wallpapers to a public folder and change their permissions to make them readable by all. By default, the folder is ~/Pictures if your home folder in not encrypted, and /usr/share/backgrounds if it is. Please use with care on multiuser systems.</property>
-                            <property name="use-markup">True</property>
-                            <property name="justify">fill</property>
-                            <property name="wrap">True</property>
-                            <property name="max-width-chars">130</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -3846,6 +3846,24 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label19">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin-top">7</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Privacy warning:&lt;/b&gt; To show your wallpaper in a display manager, it may need read permissions to the image. With this option on, Variety will copy the wallpapers to a public folder and change their permissions to make them readable by all. By default, the folder is ~/Pictures if your home folder in not encrypted, and /usr/share/backgrounds if it is. Please use with care on multiuser systems.</property>
+                            <property name="use-markup">True</property>
+                            <property name="justify">fill</property>
+                            <property name="wrap">True</property>
+                            <property name="max-width-chars">130</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">5</property>
                           </packing>
                         </child>
                       </object>

--- a/variety/data/ui/PreferencesVarietyDialog.ui
+++ b/variety/data/ui/PreferencesVarietyDialog.ui
@@ -3619,7 +3619,7 @@ To show the icon in the launcher choose About or Preferences. You may wish to lo
                         <property name="valign">start</property>
                         <property name="margin-left">15</property>
                         <property name="margin-top">18</property>
-                        <property name="label" translatable="yes">Login Screen Support</property>
+                        <property name="label" translatable="yes">Login &amp; Lock Screen Support</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>


### PR DESCRIPTION
This adds a new option under the Customize tab, as well as a new set_lock_screen script that only runs when the change lock screen option is enabled.

![vrty-lock-screen-option](https://github.com/user-attachments/assets/a62e75a8-8377-4e7b-9279-9e680d6c2b27)

Fixes #309.
Fixes #764.