### PR TITLE
Add support for default kde wallpaper plugin used by Garuda Linux

### DIFF
--- a/variety/data/scripts/set_wallpaper
+++ b/variety/data/scripts/set_wallpaper
@@ -35,6 +35,7 @@
 # In the end put the path to the actual final wallpaper image file in the WP variable.
 # The default is to simply set WP=$1.
 WP=$1
+SCRIPT_PATH="$(readlink -f "$0")"
 
 detect_desktop() {
     if [ -n "$XDG_CURRENT_DESKTOP" ]; then
@@ -152,21 +153,35 @@ if [ "$DE" == "enlightenment" ]; then
 
 elif [ "$DE" == "kde" ]; then
     plasma_qdbus_script="
+        let supportedPlugins = Array('org.kde.image', 'a2n.blur');
+        let unsupportedPlugins = [];
         let allDesktops = desktops();
         for (let d of allDesktops) {
-            if (d.wallpaperPlugin == 'org.kde.image') {
-                d.currentConfigGroup = Array('Wallpaper', 'org.kde.image', 'General');
+            if (supportedPlugins.includes(d.wallpaperPlugin)) {
+                d.currentConfigGroup = Array('Wallpaper', d.wallpaperPlugin, 'General');
                 d.writeConfig('Image', 'file://""$WP""');
             }
+            else {
+                unsupportedPlugins.push(d.wallpaperPlugin);
+            }
         }
+        print(unsupportedPlugins);
     "
-    dbus-send --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script"
+
+    plasma_qdbus_raw_result=$(dbus-send --print-reply --type=method_call --dest=org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript string:"$plasma_qdbus_script")
+    unsupported_plugins=$(echo "$plasma_qdbus_raw_result" | grep -oP '(?<=string ")[^"]*')
     dbus_exitcode="$?"
-    if [[ "$dbus_exitcode" -eq 0 && "${KDE_SESSION_VERSION}" -eq '6' ]]; then
+
+    if [[ -n "$unsupported_plugins" ]]; then
+    kdialog --title "Variety: unsupported wallpaper plugin" --passivepopup "Unsupported plugin detected: '$unsupported_plugins'\n\nIf you want to test and see if it might work, add the plugin to the supportedPlugins list in the kde section of the set_wallpaper script at $SCRIPT_PATH." --icon variety 30
+    fi
+
+    if [[ -z "$unsupported_plugins" && "$dbus_exitcode" -eq 0 && "${KDE_SESSION_VERSION}" -eq '6' ]]; then
         # Update KDE lock screen background
         kwriteconfig6 --file kscreenlockerrc --group Greeter --group Wallpaper --group org.kde.image --group General --key Image "$WP"
     fi
-    if [[ "$dbus_exitcode" -ne 0 && "${KDE_SESSION_VERSION}" -eq '5' ]]; then
+
+    if [[ -z "$unsupported_plugins" && "$dbus_exitcode" -ne 0 && "${KDE_SESSION_VERSION}" -eq '5' ]]; then
         kdialog --title "Variety: cannot change Plasma wallpaper" --passivepopup "Could not change the Plasma 5 wallpaper; \
             make sure that you're using Plasma 5.7+ and have widgets unlocked.\n----\n \
             Due to Plasma limitations, external programs cannot automatically change the wallpaper when the widgets are locked.\n \


### PR DESCRIPTION
Hi, I recently migrated from Arco Linux to Garuda Linux and was dismayed to find out that variety no longer worked (and also did not tell me what was wrong). After some digging I found out it was because they set kde to use this [blurred wallpaper plugin](https://github.com/bouteillerAlan/blurredwallpaper) which is in fact pretty cool. Based on my findings in plasma-org.kde.plasma.desktop-appletsrc, it seemed to use the same exact format as the native org.kde.image plugin. So I modified the set_wallpaper script to support this and also provide some hopefully helpful message to any user that happens to stumble across a similar situation. Of course I tested it out, but please verify my findings and let me know of any code style changes if needed. Thanks for a fantastic program!