### PR TITLE
Fix XFCE wallpaper scripts for missing backdrop properties

### DIFF
--- a/variety/data/scripts/get_wallpaper
+++ b/variety/data/scripts/get_wallpaper
@@ -12,7 +12,12 @@ if [ "$desktop" == "ubuntu" ] || [ "$XDG_CURRENT_DESKTOP" == "Unity" ] || [ "$XD
 
 # XFCE
 elif [ "$desktop" == "xubuntu" ] || [ "$XDG_CURRENT_DESKTOP" == "XFCE" ]; then
-        xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitor0/workspace0/last-image
+        # Find first existing backdrop property (monitor names vary by setup)
+        # See: https://github.com/varietywalls/variety/issues/164
+        prop=$(xfconf-query -c xfce4-desktop -p /backdrop -l 2>/dev/null | grep -E -e "screen.*/monitor.*/last-image$" -e "screen.*/monitor.*image-path$" | head -1)
+        if [ -n "$prop" ]; then
+                xfconf-query -c xfce4-desktop -p "$prop" 2>/dev/null
+        fi
 
 # Lingmo OS
 elif [ "$XDG_CURRENT_DESKTOP" == "Lingmo" ]; then

--- a/variety/data/scripts/set_wallpaper
+++ b/variety/data/scripts/set_wallpaper
@@ -210,11 +210,34 @@ elif [ "$DE" == "xfce" ]; then
     command -v xfconf-query >/dev/null 2>&1
     rc=$?
     if [[ $rc = 0 ]]; then
-        for i in $(xfconf-query -c xfce4-desktop -p /backdrop -l | grep -E -e "screen.*/monitor.*image-path$" -e "screen.*/monitor.*/last-image$"); do
-            xfconf-query -c xfce4-desktop -p "$i" -n -t string -s "" 2>/dev/null
-            xfconf-query -c xfce4-desktop -p "$i" -s "" 2>/dev/null
-            xfconf-query -c xfce4-desktop -p "$i" -s "$WP" 2>/dev/null
-        done
+        # First, try existing properties
+        existing_props=$(xfconf-query -c xfce4-desktop -p /backdrop -l 2>/dev/null | grep -E -e "screen.*/monitor.*image-path$" -e "screen.*/monitor.*/last-image$")
+
+        if [ -n "$existing_props" ]; then
+            # Set wallpaper on existing properties
+            for i in $existing_props; do
+                xfconf-query -c xfce4-desktop -p "$i" -n -t string -s "" 2>/dev/null
+                xfconf-query -c xfce4-desktop -p "$i" -s "" 2>/dev/null
+                xfconf-query -c xfce4-desktop -p "$i" -s "$WP" 2>/dev/null
+            done
+        else
+            # No existing properties - create them for each connected monitor
+            # This handles fresh XFCE installs where backdrop properties don't exist yet
+            # See: https://github.com/varietywalls/variety/issues/164
+            if command -v xrandr >/dev/null 2>&1; then
+                for monitor in $(xrandr --query | grep " connected" | cut -d' ' -f1); do
+                    prop="/backdrop/screen0/monitor${monitor}/workspace0/last-image"
+                    style_prop="/backdrop/screen0/monitor${monitor}/workspace0/image-style"
+                    # Create and set the wallpaper property
+                    xfconf-query -c xfce4-desktop -p "$prop" -n -t string -s "$WP" 2>/dev/null
+                    # Set image style to 5 (zoomed) if not already set
+                    xfconf-query -c xfce4-desktop -p "$style_prop" -n -t int -s 5 2>/dev/null
+                done
+            else
+                # Fallback: try common property path with --create flag
+                xfconf-query -c xfce4-desktop -p "/backdrop/screen0/monitor0/workspace0/last-image" -n -t string -s "$WP" 2>/dev/null
+            fi
+        fi
     fi
 
 elif [ "$DE" == "lingmo" ]; then


### PR DESCRIPTION
## Summary

Fixes #164

On fresh XFCE installs or systems where wallpaper was never set via XFCE, the backdrop properties (e.g., `/backdrop/screen0/monitor0/workspace0/last-image`) don't exist. This causes both `set_wallpaper` and `get_wallpaper` scripts to fail.

### Changes to `set_wallpaper`:
- Check if existing backdrop properties exist first
- If none exist, detect connected monitors via `xrandr` and create properties using `xfconf-query --create` (`-n`) flag
- Set a sensible default image-style (5 = zoomed)

### Changes to `get_wallpaper`:
- Dynamically find the first existing backdrop property instead of hardcoding `monitor0`
- Handle missing properties gracefully by returning nothing instead of erroring

## Test plan

- [x] Tested on XFCE with missing backdrop properties (fresh state)
- [x] Verified `set_wallpaper` creates properties for all connected monitors
- [x] Verified `get_wallpaper` returns the correct path after properties exist
- [x] Verified Variety starts without errors after fix