### PR TITLE
Fix bare except clauses in VarietyWindow.py

### DIFF
--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1155,7 +1155,7 @@ class VarietyWindow(Gtk.Window):
     def download_one_from(self, downloader):
         try:
             file = downloader.download_one()
-        except:
+        except Exception:
             logger.exception(lambda: "Could not download wallpaper:")
             file = None
 
@@ -2079,7 +2079,7 @@ class VarietyWindow(Gtk.Window):
                     try:
                         gio_file = Gio.File.new_for_path(file)
                         ok = gio_file.trash()
-                    except:
+                    except Exception:
                         logger.exception("Gio.File.trash failed with exception")
                         ok = False
 
@@ -2700,7 +2700,7 @@ class VarietyWindow(Gtk.Window):
                     _("Unsupported command"),
                     _("Are you running the most recent version of Variety?"),
                 )
-        except:
+        except Exception:
             self.show_notification(
                 _("Could not process the given variety:// URL"),
                 _("Run with logging enabled to see details"),
@@ -3180,7 +3180,7 @@ class VarietyWindow(Gtk.Window):
                 if self.options.slideshow_monitor.lower() != "all":
                     try:
                         args += ["--monitor", str(int(self.options.slideshow_monitor))]
-                    except:
+                    except Exception:
                         pass
                     subprocess.Popen(args)
                 else:
@@ -3189,7 +3189,7 @@ class VarietyWindow(Gtk.Window):
                         new_args = list(args)
                         new_args += ["--monitor", str(i + 1)]
                         subprocess.Popen(new_args)
-            except:
+            except Exception:
                 logger.exception("Could not start slideshow:")
 
         threading.Thread(target=_go).start()


### PR DESCRIPTION
## Problem

This PR fixes 5 instances of bare `except:` clauses in `VarietyWindow.py` that could catch system-level exceptions like `KeyboardInterrupt` and `SystemExit`.

## What Changed

Changed `except:` to `except Exception:` in the following locations:
- Line 1158: `download_one_from` method
- Line 2082: file trashing operation  
- Line 2703: variety:// URL processing
- Line 3183: slideshow monitor parsing
- Line 3192: slideshow startup

## Why This Matters

Bare except clauses catch **all** exceptions including system-level ones like:
- `KeyboardInterrupt` (Ctrl+C)
- `SystemExit` (program shutdown)
- `GeneratorExit`

This can:
- Make the program impossible to interrupt with Ctrl+C
- Mask critical shutdown signals
- Hide serious bugs that should propagate

## Testing

The fix maintains the same error handling behavior for regular exceptions while allowing system exceptions to propagate correctly. All existing error logging is preserved.

## References

- [PEP 8: Programming Recommendations](https://peps.python.org/pep-0008/#programming-recommendations)
- [Python Best Practices: Never use bare except](https://realpython.com/the-most-diabolical-python-antipattern/)