### PR TITLE
Adding fix for fedora 44

### DIFF
--- a/variety/Util.py
+++ b/variety/Util.py
@@ -42,7 +42,12 @@ from variety_lib import get_version
 
 # fmt: off
 import gi  # isort:skip
-gi.require_version("GExiv2", "0.10")
+for _gexiv2_ver in ("0.16", "0.14", "0.12", "0.10"):
+    try:
+        gi.require_version("GExiv2", _gexiv2_ver)
+        break
+    except ValueError:
+        pass
 gi.require_version("PangoCairo", "1.0")
 gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk, GdkPixbuf, GExiv2, Gio, GLib, Pango  # isort:skip


### PR DESCRIPTION
This will check different versions of `GExiv2` starting with more recent and falling back to older versions.

Fixes https://github.com/varietywalls/variety/issues/834

P.S. Great tool, love the variety!