### PR TITLE
Fix for IMAGEMAGICK_FIT_WITH_BLUR command

### DIFF
--- a/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
+++ b/variety/plugins/builtin/display_modes/ResizingDisplayModesPlugin.py
@@ -11,8 +11,10 @@ from variety.Util import Util, _
 IMAGEMAGICK_ZOOM = "-scale %Wx%H^ "
 IMAGEMAGICK_FIT_WITH_BLACK = "-resize %Wx%H -size %Wx%H xc:black +swap -gravity center -composite"
 IMAGEMAGICK_FIT_WITH_BLUR = (
-    "-resize %Wx%H^ -gravity center -extent %Wx%H -scale 10% -blur 0x3 -resize 1000% -clone 0 "
-    "-resize %Wx%H -size %Wx%H -gravity center -composite"
+    "-write mpr:src +delete "
+    "\( mpr:src -resize %Wx%H^ -gravity center -extent %Wx%H -scale 10% -blur 0x3 -resize 1000% \) "
+    "\( mpr:src -resize %Wx%H -background none -gravity center -extent %Wx%H \) "
+    "-composite"
 )
 IMAGEMAGICK_TILE = "-write mpr:x -delete -1 -size %Wx%H tile:mpr:x "
 


### PR DESCRIPTION
For quite a while I noticed the "Fit within screen, pad with a blurred background" option was broken on my system.
It generated a fully blurred image without the original overlaid on top.
Looking at the git blame I see no changes there, so maybe it was a change in imagemagick itself.

Looking at my logs, this was the imagemagick command, that when run isolated was in fact generating the fully blurred image:
```
magick input.jpg \
	-resize 2560x1440^ -gravity center -extent 2560x1440 -scale 10% -blur 0x3 -resize 1000% \
	-clone 0 -resize 2560x1440 -size 2560x1440 -gravity center \
	-composite output_old.jpg
```

This is the new command, that works as expected:
```
magick input.jpg \
	-write mpr:src +delete \
	\( mpr:src -resize 2560x1440^ -gravity center -extent 2560x1440 -scale 10% -blur 0x3 -resize 1000% \) \
	\( mpr:src -resize 2560x1440 -background none -gravity center -extent 2560x1440 \) \
	-composite output_new.jpg
```

Surprised I didn't see any bug reports related to this. Even if this is isolated to Debian testing or whatever, the new imagemagick command is more explicit and shouldn't break any system.
```
magick --version
Version: ImageMagick 7.1.2-18 Q16 x86_64 23822 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/license/
Features: Cipher DPC Modules OpenMP(4.5) 
Delegates (built-in): bzlib djvu fftw fontconfig freetype heic jbig jng jp2 jpeg lcms lqr ltdl lzma openexr pangocairo png raw tiff webp wmf x xml zlib zstd
Compiler: gcc (15.2)
```

Here is a image comparing the two outputs for a portrait image, one where Variety's auto-mode would choose "Fit within screen, pad with a blurred background" fitting.

<img width="2560" height="1440" alt="comparision" src="https://github.com/user-attachments/assets/7db3417e-2acb-4192-a8a3-a87b724794b1" />

Disclaimer: The imagemagick command was partially generated by a LLM, but from my review seems correct and straightforward enough (I'd argue simpler than the original).