### PR TITLE
Fix clock overlay

### DIFF
--- a/variety/Options.py
+++ b/variety/Options.py
@@ -28,7 +28,7 @@ TRUTH_VALUES = ["enabled", "1", "true", "on", "yes"]
 
 
 class Options:
-    OUTDATED_HASHES = {"clock_filter": ["dca6bd2dfa2b8c4e2db8801e39208f7f"]}
+    OUTDATED_HASHES = {"clock_filter": ["dca6bd2dfa2b8c4e2db8801e39208f7f", "a565a0c34a1358af4fb040d30cca6933"]}
     SIMPLE_DOWNLOADERS = []  # set by VarietyWindow at start
     IMAGE_SOURCES = []  # set by VarietyWindow at start
     CONFIGURABLE_IMAGE_SOURCES = []  # set by VarietyWindow at start
@@ -699,7 +699,7 @@ class Options:
         self.clock_enabled = False
         self.clock_font = "Serif 70"
         self.clock_date_font = "Serif 30"
-        self.clock_filter = "-density 100 -font `fc-match -f '%{file[0]}' '%CLOCK_FONT_NAME'` -pointsize %CLOCK_FONT_SIZE -gravity SouthEast -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+108] '%H:%M' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+110] '%H:%M' -font `fc-match -f '%{file[0]}' '%DATE_FONT_NAME'` -pointsize %DATE_FONT_SIZE -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+58] '%A, %B %d' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+60] '%A, %B %d'"
+        self.clock_filter = "-density 100 -font '%CLOCK_FONT_FILE' -pointsize %CLOCK_FONT_SIZE -gravity SouthEast -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+108] '%H:%M' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+110] '%H:%M' -font '%DATE_FONT_FILE' -pointsize %DATE_FONT_SIZE -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+58] '%A, %B %d' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+60] '%A, %B %d'"
 
         self.quotes_enabled = False
         self.quotes_font = "Serif 30"

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1301,12 +1301,29 @@ class VarietyWindow(Gtk.Window):
         logger.info(lambda: f"ImageMagick clock args: {cmd}")
         return cmd
 
+    @staticmethod
+    @functools.cache
+    def resolve_font_path(font_name):
+        cmd = ['fc-match', '-f', '%{file[0]}', font_name]
+        result = subprocess.run(cmd, check=False, text=True, stdout=subprocess.PIPE)
+        font_file = ""
+        if result.returncode == 0:
+            font_file = result.stdout
+        else:
+            logger.warning(
+                lambda: f"Could not find font '{font_name}'. "
+                f"Exit code: {result.returncode}"
+            )
+        return font_file
+
     def replace_clock_filter_fonts(self, clock_filter):
         clock_font_name, clock_font_size = Util.gtk_to_fcmatch_font(self.options.clock_font)
+        clock_font_file = self.resolve_font_path(clock_font_name)
         date_font_name, date_font_size = Util.gtk_to_fcmatch_font(self.options.clock_date_font)
-        clock_filter = clock_filter.replace("%CLOCK_FONT_NAME", clock_font_name)
+        date_font_file = self.resolve_font_path(date_font_name)
+        clock_filter = clock_filter.replace("%CLOCK_FONT_FILE", clock_font_file)
         clock_filter = clock_filter.replace("%CLOCK_FONT_SIZE", clock_font_size)
-        clock_filter = clock_filter.replace("%DATE_FONT_NAME", date_font_name)
+        clock_filter = clock_filter.replace("%DATE_FONT_FILE", date_font_file)
         clock_filter = clock_filter.replace("%DATE_FONT_SIZE", date_font_size)
         return clock_filter
 

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1311,7 +1311,7 @@ class VarietyWindow(Gtk.Window):
             font_file = result.stdout
         else:
             logger.warning(
-                lambda: f"Could not find font '{font_name}'. "
+                lambda: f"Could not find font {font_name!r}. "
                 f"Exit code: {result.returncode}"
             )
         return font_file

--- a/variety/data/config/variety.conf
+++ b/variety/data/config/variety.conf
@@ -167,7 +167,7 @@ clock_date_font = "Serif 30"
 # A tutorial on "annotating" with ImageMagick that you may use as a reference: http://www.imagemagick.org/Usage/annotating/
 # You can get a very uniquely looking clock with some of the more advanced techniques (e.g. circle-shaped text, interesting colors and shading, etc....).
 
-clock_filter = "-density 100 -font `fc-match -f '%{file[0]}' '%CLOCK_FONT_NAME'` -pointsize %CLOCK_FONT_SIZE -gravity SouthEast -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+108] '%H:%M' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+110] '%H:%M' -font `fc-match -f '%{file[0]}' '%DATE_FONT_NAME'` -pointsize %DATE_FONT_SIZE -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+58] '%A, %B %d' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+60] '%A, %B %d'"
+clock_filter = "-density 100 -font '%CLOCK_FONT_FILE' -pointsize %CLOCK_FONT_SIZE -gravity SouthEast -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+108] '%H:%M' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+110] '%H:%M' -font '%DATE_FONT_FILE' -pointsize %DATE_FONT_SIZE -fill '#00000044' -annotate 0x0+[%HOFFSET+58]+[%VOFFSET+58] '%A, %B %d' -fill white -annotate 0x0+[%HOFFSET+60]+[%VOFFSET+60] '%A, %B %d'"
 
 # Quotes settings
 # quotes_enabled = <True or False>


### PR DESCRIPTION
Variety 0.9 included a change to the clock command runner that used `shlex.split()` to break down the cmdline used to apply the clock to individual parameters and pass that to `subprocess.run()`.
Using `subprocess.run()` is certainly a better approach, but `shlex.split()` doesn't handle command substitution (`` `cmd` `` or `$(cmd)` syntax) so the clock was broken entirely with this error:
`apply_clock() 'Could not execute clock magick command. Missing ImageMagick or bad filter defined? Exit code: 11'`

This patch uses a f-string to build the cmdline and `subprocess.run(shell=True)` to run it. Another approach would be to run the `fc-match` commands separately and merge the results as separate parameters, but I don't think this would be desirable here.
Using the shell to run the clock commands is a more familiar syntax, allows for easier changes to the command in the future, and allows for more customizable clock commands should the user need it.
Looking at the related commits there are other places that were changes to use `subprocess.run()`, but since none of them use any shell features I decided to leave them alone.