### PR TITLE
set_wallpaper: use processed wallpaper path on Cosmic DE

### DIFF
--- a/variety/data/scripts/set_wallpaper
+++ b/variety/data/scripts/set_wallpaper
@@ -344,7 +344,12 @@ elif [ "$DE" == "awesome" ]; then
 
 elif [[ "$XDG_CURRENT_DESKTOP" == "COSMIC" ]]; then
     # $WP includes clock/quotes overlays; $3 is the original image without them.
-    sed -r --in-place 's,source: Path\(".+"\),source: Path("'"$WP"'"),gm' ~/.config/cosmic/com.system76.CosmicBackground/v1/all
+    # Also replace Color(...) so solid-color backgrounds become an image path.
+    COSMIC_BG="$HOME/.config/cosmic/com.system76.CosmicBackground/v1/all"
+    sed -r --in-place \
+        -e 's,source: Path\(".+"\),source: Path("'"$WP"'"),gm' \
+        -e 's,source: Color\(.+\),source: Path("'"$WP"'"),gm' \
+        "$COSMIC_BG"
 
 else
     # For simple WMs, use either feh or nitrogen

--- a/variety/data/scripts/set_wallpaper
+++ b/variety/data/scripts/set_wallpaper
@@ -343,7 +343,8 @@ elif [ "$DE" == "awesome" ]; then
     echo "for s in screen do require(\"gears\").wallpaper.maximized(\"$1\", s) end" | awesome-client
 
 elif [[ "$XDG_CURRENT_DESKTOP" == "COSMIC" ]]; then
-    sed -r --in-place 's,source: Path\(".+"\),source: Path("'"$3"'"),gm' ~/.config/cosmic/com.system76.CosmicBackground/v1/all
+    # $WP includes clock/quotes overlays; $3 is the original image without them.
+    sed -r --in-place 's,source: Path\(".+"\),source: Path("'"$WP"'"),gm' ~/.config/cosmic/com.system76.CosmicBackground/v1/all
 
 else
     # For simple WMs, use either feh or nitrogen


### PR DESCRIPTION
## Summary
- Cosmic `set_wallpaper` wrote `$3` (original image) into `~/.config/cosmic/com.system76.CosmicBackground/v1/all`, so clock/quotes overlays never appeared on the desktop.
- Switch Cosmic to `$WP` (same as GNOME/KDE/XFCE/etc.).
- Also rewrite `source: Color(...)` to `source: Path("$WP")`, so Variety still works when Cosmic is set to a solid-color background (the Path-only sed previously no-oped).
- Change is confined to the Cosmic branch only.

## Context
- Clock overlay font/`fc-match` issue is already fixed upstream in #844; this PR addresses Cosmic path/color handling.
- Tested on Pop!_OS Cosmic (Wayland).

## Test plan
- [ ] On Cosmic with an image background: enable quotes + clock, change wallpaper; confirm overlays appear.
- [ ] On Cosmic with a solid-color background: run Variety change; confirm wallpaper becomes the Variety image.
- [ ] Spot-check that GNOME/KDE/XFCE paths are untouched (diff is Cosmic-only).
