### PR TITLE
Add native Windows support (MSYS2/GTK3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Variety can also display wise and funny quotations or a nice digital clock on th
 Where supported, Variety sits as a tray icon to allow easy pausing and resuming.
 Otherwise, its desktop entry menu provides a similar set of options.
 
+Variety also runs natively on Windows via MSYS2/GTK3 - see [WINDOWS.md](WINDOWS.md).
+
 ## Screenshot
 
 ![Screenshot from 2022-07-30 16-36-55](https://user-images.githubusercontent.com/1457048/181916884-8a388e15-67dc-45ff-a8e2-e05aac7fca91.png)

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,85 @@
+# Running Variety on Windows
+
+Variety now runs natively on Windows, on top of a real Windows-native GTK3 build
+provided by [MSYS2](https://www.msys2.org/) - no WSL, no Linux VM, no Cygwin.
+This is a young port; please report issues and mention you're on Windows.
+
+## Setup
+
+1. **Install MSYS2**: https://www.msys2.org/ (or `winget install MSYS2.MSYS2`).
+   No admin rights or reboot required.
+
+2. **Install the GTK3/Python/gexiv2 toolchain.** Open "MSYS2 UCRT64" from the
+   Start menu (or run `C:\msys64\usr\bin\bash.exe -lc "..."`) and run:
+
+   ```bash
+   pacman -Syu   # first run will ask you to restart the shell, do that and rerun
+   pacman -S mingw-w64-ucrt-x86_64-gtk3 mingw-w64-ucrt-x86_64-python \
+             mingw-w64-ucrt-x86_64-python-gobject mingw-w64-ucrt-x86_64-python-cairo \
+             mingw-w64-ucrt-x86_64-gexiv2 mingw-w64-ucrt-x86_64-python-pip \
+             mingw-w64-ucrt-x86_64-python-requests mingw-w64-ucrt-x86_64-python-pillow \
+             mingw-w64-ucrt-x86_64-python-beautifulsoup4 mingw-w64-ucrt-x86_64-python-lxml \
+             mingw-w64-ucrt-x86_64-python-httplib2 mingw-w64-ucrt-x86_64-libnotify \
+             mingw-w64-ucrt-x86_64-imagemagick
+   ```
+
+3. **Create a venv with access to those system packages** (pip can't install
+   GTK/GObject bindings itself - they're tied to native DLLs pacman installs):
+
+   ```bash
+   /ucrt64/bin/python.exe -m venv --system-site-packages /path/to/venv
+   /path/to/venv/bin/python.exe -m pip install configobj
+   ```
+
+   (`dbus-python` from `pyproject.toml` is intentionally skipped - see
+   "What's different" below.)
+
+4. **Run it**, from a checkout of this repo:
+
+   ```bash
+   /path/to/venv/bin/python.exe path/to/variety/run_variety.py
+   ```
+
+   For a normal double-click launcher with no console window, point a
+   shortcut (or a `.bat` using `start "" "...\venv\bin\pythonw.exe" ...`) at
+   `pythonw.exe` instead of `python.exe`.
+
+5. **Autostart**: Preferences -> General -> the autostart checkbox now writes
+   a `.vbs` launcher into your Windows Startup folder instead of a Linux
+   `.desktop` file.
+
+## What's different on Windows
+
+Windows has no D-Bus, no gsettings, no libnotify daemon, and no XDG autostart
+convention, so a handful of things are implemented differently rather than
+simply disabled:
+
+- **Wallpaper get/set**: `SystemParametersInfoW` + registry
+  (`Util.set_windows_wallpaper` / `get_windows_wallpaper`) instead of the
+  `set_wallpaper`/`get_wallpaper` shell scripts.
+- **Lock screen**: the WinRT `Windows.System.UserProfile.LockScreen` API
+  (`Util.set_windows_lock_screen`), invoked through PowerShell's built-in WinRT
+  projection support so no extra Python package is required. Note some
+  managed/corporate machines restrict this via policy - the call is wrapped
+  and logged, not fatal, if that happens.
+- **Single instance + IPC** (used for `--profile`, passing a `variety://` URL
+  to an already-running instance, etc.): a loopback TCP socket with a
+  per-profile shared-secret token (`variety/win_ipc.py`), since there's no
+  session bus to piggyback on.
+- **Desktop notifications**: shown via libnotify when available; caught and
+  logged (not fatal) when there's no notification service listening.
+- **Tray icon**: falls back to `Gtk.StatusIcon` (no AppIndicator on Windows).
+  Its popup menu is positioned at the pointer rather than via
+  `Gtk.StatusIcon.position_menu`, which miscalculates the icon's screen
+  geometry under the GTK win32 backend.
+- **Autostart**: a `.vbs` script in the Startup folder instead of a
+  `~/.config/autostart/*.desktop` file.
+- **Open file/folder, edit config**: `os.startfile` / `notepad` instead of
+  `xdg-open` / `gedit`.
+
+## Known gaps
+
+- The "Fortune" quotes source needs the Linux `fortune` binary; it's skipped
+  cleanly (not an error) when unavailable, which is always the case on
+  Windows unless you separately install a fortune-mod port.
+- `variety-slideshow` isn't packaged for Windows.

--- a/run_variety.py
+++ b/run_variety.py
@@ -1,0 +1,3 @@
+from variety import main
+
+main()

--- a/variety/ImageFetcher.py
+++ b/variety/ImageFetcher.py
@@ -135,7 +135,7 @@ class ImageFetcher:
             metadata.update(extra_metadata or {})
             Util.write_metadata(local_filepath_partial, metadata)
 
-            os.rename(local_filepath_partial, filename)
+            os.replace(local_filepath_partial, filename)
             logger.info(lambda: "Fetched %s to %s." % (url, filename))
             return filename
 

--- a/variety/Util.py
+++ b/variety/Util.py
@@ -784,7 +784,7 @@ class Util:
     @staticmethod
     def collapseuser(path):
         home = os.path.expanduser("~") + "/"
-        return re.sub("^" + home, "~/", path)
+        return re.sub("^" + re.escape(home), "~/", path)
 
     @staticmethod
     def compare_versions(v1, v2):
@@ -821,8 +821,12 @@ class Util:
 
     @staticmethod
     def get_file_icon_name(path):
+        resolved = os.path.normpath(os.path.expanduser(path))
+        if not os.path.exists(resolved):
+            # expected e.g. for stock Linux source paths that don't exist on this platform
+            return "folder"
         try:
-            f = Gio.File.new_for_path(os.path.normpath(os.path.expanduser(path)))
+            f = Gio.File.new_for_path(resolved)
             query_info = f.query_info("standard::icon", Gio.FileQueryInfoFlags.NONE, None)
             return query_info.get_attribute_object("standard::icon").get_names()[0]
         except Exception:
@@ -909,6 +913,92 @@ class Util:
     def is_unity():
         return os.getenv("XDG_CURRENT_DESKTOP", "").lower() == "unity"
 
+    # Windows has no gsettings/D-Bus wallpaper API, so on that platform
+    # set_desktop_wallpaper (VarietyWindow.py) calls this directly instead of
+    # running the Linux set_wallpaper script.
+    @staticmethod
+    def set_windows_wallpaper(path, display_mode="zoom"):
+        import ctypes
+        import winreg
+
+        # (WallpaperStyle, TileWallpaper) - see
+        # https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-systemparametersinfow
+        style_by_mode = {
+            "zoom": ("10", "0"),
+            "scaled": ("6", "0"),
+            "stretched": ("2", "0"),
+            "centered": ("0", "0"),
+            "spanned": ("22", "0"),
+            "wallpaper": ("0", "1"),
+        }
+        wallpaper_style, tile_wallpaper = style_by_mode.get(display_mode, ("10", "0"))
+
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, r"Control Panel\Desktop", 0, winreg.KEY_SET_VALUE
+        ) as key:
+            winreg.SetValueEx(key, "WallpaperStyle", 0, winreg.REG_SZ, wallpaper_style)
+            winreg.SetValueEx(key, "TileWallpaper", 0, winreg.REG_SZ, tile_wallpaper)
+
+        SPI_SETDESKWALLPAPER = 20
+        SPIF_UPDATEINIFILE = 0x01
+        SPIF_SENDCHANGE = 0x02
+        ctypes.windll.user32.SystemParametersInfoW(
+            SPI_SETDESKWALLPAPER, 0, os.path.abspath(path), SPIF_UPDATEINIFILE | SPIF_SENDCHANGE
+        )
+
+    @staticmethod
+    def set_windows_lock_screen(path):
+        # Uses the WinRT Windows.System.UserProfile.LockScreen API, the documented,
+        # no-admin-required way for a desktop app to set the current user's lock
+        # screen image. Invoked via PowerShell's built-in WinRT projection support
+        # so we don't need a winrt Python package (those lag far behind new CPython
+        # releases and aren't guaranteed to have wheels for the interpreter in use).
+        #
+        # Windows PowerShell 5.1 (the version guaranteed present on every Windows
+        # install) doesn't expose .GetAwaiter() on WinRT async objects the way
+        # PowerShell 7+/C# does, so we drive the IAsyncOperation/IAsyncAction via
+        # reflection instead - the standard workaround for awaiting WinRT calls
+        # from stock Windows PowerShell.
+        script = (
+            "$ErrorActionPreference = 'Stop'; "
+            "Add-Type -AssemblyName System.Runtime.WindowsRuntime | Out-Null; "
+            "Function Await($WinRtTask, $ResultType) { "
+            "  $asTask = ([System.WindowsRuntimeSystemExtensions].GetMethods() | "
+            "    Where-Object { $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and "
+            "    $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation`1' })[0]; "
+            "  $netTask = $asTask.MakeGenericMethod($ResultType).Invoke($null, @($WinRtTask)); "
+            "  try { $netTask.Wait(-1) | Out-Null } catch { throw $_.Exception.InnerException }; "
+            "  $netTask.Result "
+            "}; "
+            "Function AwaitAction($WinRtAction) { "
+            "  $asTask = ([System.WindowsRuntimeSystemExtensions].GetMethods() | "
+            "    Where-Object { $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and "
+            "    $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncAction' })[0]; "
+            "  $netTask = $asTask.Invoke($null, @($WinRtAction)); "
+            "  try { $netTask.Wait(-1) | Out-Null } catch { throw $_.Exception.InnerException }; "
+            "}; "
+            "[Windows.System.UserProfile.LockScreen,Windows.System.UserProfile,ContentType=WindowsRuntime] | Out-Null; "
+            "[Windows.Storage.StorageFile,Windows.Storage,ContentType=WindowsRuntime] | Out-Null; "
+            "$file = Await ([Windows.Storage.StorageFile]::GetFileFromPathAsync('%PATH%')) ([Windows.Storage.StorageFile]); "
+            "AwaitAction ([Windows.System.UserProfile.LockScreen]::SetImageFileAsync($file)); "
+        ).replace(
+            "%PATH%", os.path.abspath(path).replace("/", "\\").replace("'", "''")
+        )
+        subprocess.run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
+            check=True,
+            timeout=20,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def get_windows_wallpaper():
+        import winreg
+
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\Desktop") as key:
+            value, _type = winreg.QueryValueEx(key, "Wallpaper")
+        return value or None
+
     @staticmethod
     def start_daemon(target):
         daemon_thread = threading.Thread(target=target)
@@ -943,7 +1033,7 @@ class Util:
         with open(to_path + ".partial", "w") as file:
             file.write(data)
             file.flush()
-        os.rename(to_path + ".partial", to_path)
+        os.replace(to_path + ".partial", to_path)
 
     @staticmethod
     def get_exec_path():

--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -68,7 +68,7 @@ from variety_lib import varietyconfig
 import gi  # isort:skip
 
 gi.require_version("Notify", "0.7")
-from gi.repository import Gdk, Gio, GObject, Gtk, Notify  # isort:skip
+from gi.repository import Gdk, Gio, GLib, GObject, Gtk, Notify  # isort:skip
 Notify.init("Variety")
 # fmt: on
 
@@ -1679,18 +1679,23 @@ class VarietyWindow(Gtk.Window):
         if not icon:
             icon = varietyconfig.get_data_file("media", "variety.svg")
 
-        if not important:
-            try:
-                self.notification.update(title, message, icon)
-            except AttributeError:
-                self.notification = Notify.Notification.new(title, message, icon)
-            self.notification.set_urgency(Notify.Urgency.LOW)
-            self.notification.show()
-        else:
-            # use a separate notification that will not be updated with a non-important message
-            notification = Notify.Notification.new(title, message, icon)
-            notification.set_urgency(Notify.Urgency.NORMAL)
-            notification.show()
+        try:
+            if not important:
+                try:
+                    self.notification.update(title, message, icon)
+                except AttributeError:
+                    self.notification = Notify.Notification.new(title, message, icon)
+                self.notification.set_urgency(Notify.Urgency.LOW)
+                self.notification.show()
+            else:
+                # use a separate notification that will not be updated with a non-important message
+                notification = Notify.Notification.new(title, message, icon)
+                notification.set_urgency(Notify.Urgency.NORMAL)
+                notification.show()
+        except GLib.GError:
+            # No notification daemon is listening (e.g. on Windows, there is no
+            # org.freedesktop.Notifications service). Not fatal, just skip showing it.
+            logger.debug(lambda: "No notification service available to show: %s" % title)
 
     def _has_local_sources(self):
         return (
@@ -1942,13 +1947,19 @@ class VarietyWindow(Gtk.Window):
         if not file:
             file = self.current
         if file:
-            subprocess.Popen(["xdg-open", os.path.dirname(file)])
+            if sys.platform == "win32":
+                os.startfile(os.path.dirname(file))
+            else:
+                subprocess.Popen(["xdg-open", os.path.dirname(file)])
 
     def open_file(self, widget=None, file=None):
         if not file:
             file = self.current
         if file:
-            subprocess.Popen(["xdg-open", os.path.realpath(file)])
+            if sys.platform == "win32":
+                os.startfile(os.path.realpath(file))
+            else:
+                subprocess.Popen(["xdg-open", os.path.realpath(file)])
 
     def on_show_origin(self, widget=None):
         if self.url:
@@ -2454,7 +2465,8 @@ class VarietyWindow(Gtk.Window):
         dialog.run()
         dialog.destroy()
         self.dialogs.remove(dialog)
-        subprocess.call(["gedit", os.path.join(self.config_folder, "variety.conf")])
+        editor = "notepad" if sys.platform == "win32" else "gedit"
+        subprocess.call([editor, os.path.join(self.config_folder, "variety.conf")])
         self.reload_config()
 
     def on_pause_resume(self, widget=None, change_enabled=None):
@@ -2729,6 +2741,9 @@ class VarietyWindow(Gtk.Window):
 
     def get_desktop_wallpaper(self):
         try:
+            if sys.platform == "win32":
+                return Util.get_windows_wallpaper()
+
             script = self.options.get_wallpaper_script
 
             file = None
@@ -2779,6 +2794,19 @@ class VarietyWindow(Gtk.Window):
             logger.exception(lambda: "Cannot remove all old wallpaper files from %s:" % folder)
 
     def set_desktop_wallpaper(self, wallpaper, original_file, refresh_level, display_mode, lock_screen=False):
+        if sys.platform == "win32":
+            if lock_screen:
+                try:
+                    Util.set_windows_lock_screen(wallpaper)
+                except Exception:
+                    logger.exception(lambda: "Could not set the Windows lock screen image")
+                return
+            try:
+                Util.set_windows_wallpaper(wallpaper, display_mode)
+            except Exception:
+                logger.exception(lambda: "Could not set the Windows desktop wallpaper")
+            return
+
         script = self.options.set_lock_screen_script if lock_screen else self.options.set_wallpaper_script
         if os.access(script, os.X_OK):
             auto = (
@@ -3009,7 +3037,10 @@ class VarietyWindow(Gtk.Window):
 
     def quote_view_favorites(self, widget=None):
         if os.path.isfile(self.options.quotes_favorites_file):
-            subprocess.Popen(["xdg-open", self.options.quotes_favorites_file])
+            if sys.platform == "win32":
+                os.startfile(self.options.quotes_favorites_file)
+            else:
+                subprocess.Popen(["xdg-open", self.options.quotes_favorites_file])
 
     def on_quotes_pause_resume(self, widget=None, change_enabled=None):
         if change_enabled is None:
@@ -3102,20 +3133,35 @@ class VarietyWindow(Gtk.Window):
             Util.makedirs(os.path.dirname(autostart_file_path))
             should_notify = not os.path.exists(autostart_file_path)
 
-            Util.copy_with_replace(
-                varietyconfig.get_data_file("variety-autostart.desktop.template"),
-                autostart_file_path,
-                {
-                    "{PROFILE_PATH}": get_profile_path(expanded=True),
-                    "{VARIETY_PATH}": Util.get_exec_path(),
-                    "{WM_CLASS}": get_profile_wm_class(),
-                },
-            )
+            if sys.platform == "win32":
+                pythonw = os.path.join(os.path.dirname(sys.executable), "pythonw.exe")
+                run_cmd = '"{}" "{}" --profile "{}"'.format(
+                    pythonw, Util.get_exec_path(), get_profile_path(expanded=True)
+                )
+                vbs_content = (
+                    "Set shell = CreateObject(\"WScript.Shell\")\r\n"
+                    "WScript.Sleep 10000\r\n"
+                    'shell.Run "{}", 0, False\r\n'
+                ).format(run_cmd.replace('"', '""'))
+                with open(autostart_file_path, "w", encoding="utf-8") as f:
+                    f.write(vbs_content)
+            else:
+                Util.copy_with_replace(
+                    varietyconfig.get_data_file("variety-autostart.desktop.template"),
+                    autostart_file_path,
+                    {
+                        "{PROFILE_PATH}": get_profile_path(expanded=True),
+                        "{VARIETY_PATH}": Util.get_exec_path(),
+                        "{WM_CLASS}": get_profile_wm_class(),
+                    },
+                )
 
             if should_notify:
                 self.show_notification(
-                    _("Variety: Created autostart desktop entry"),
-                    _(
+                    _("Variety: Created autostart entry"),
+                    _("Variety should start automatically on next login.")
+                    if sys.platform == "win32"
+                    else _(
                         "We created a new desktop entry in ~/.config/autostart. "
                         "Variety should start automatically on next login."
                     ),
@@ -3133,7 +3179,7 @@ class VarietyWindow(Gtk.Window):
     def on_start_slideshow(self, widget=None):
         def _go():
             try:
-                if self.options.slideshow_mode.lower() != "window":
+                if self.options.slideshow_mode.lower() != "window" and sys.platform != "win32":
                     subprocess.call(["killall", "-9", "variety-slideshow"])
 
                 args = ["variety-slideshow"]

--- a/variety/__init__.py
+++ b/variety/__init__.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import signal
+import subprocess
 import sys
 
 import gi
@@ -33,6 +34,21 @@ except ImportError:
     # dbus-python isn't available on Windows (there is no session bus). We fall
     # back to a local TCP-based single-instance/IPC mechanism in variety.win_ipc.
     HAVE_DBUS = False
+
+if sys.platform == "win32":
+    # We shell out to a handful of console tools (ImageMagick for filters/clock/
+    # quotes, fc-match, PowerShell for the lock screen API). Every subprocess.Popen
+    # call from a GUI (pythonw) process would otherwise flash a console window open
+    # for the duration of the call. Patched once, here, rather than passing
+    # creationflags at each of the many call sites - and it also covers any
+    # subprocess call added later.
+    _real_popen_init = subprocess.Popen.__init__
+
+    def _no_console_popen_init(self, *args, **kwargs):
+        kwargs["creationflags"] = kwargs.get("creationflags", 0) | subprocess.CREATE_NO_WINDOW
+        _real_popen_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = _no_console_popen_init
 
 
 class SafeLogger(logging.Logger):

--- a/variety/__init__.py
+++ b/variety/__init__.py
@@ -15,7 +15,6 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 ### END LICENSE
 
-import dbus, dbus.service, dbus.glib
 import logging
 import os
 import signal
@@ -25,6 +24,15 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject  # pylint: disable=E0611
+
+try:
+    import dbus, dbus.service
+
+    HAVE_DBUS = True
+except ImportError:
+    # dbus-python isn't available on Windows (there is no session bus). We fall
+    # back to a local TCP-based single-instance/IPC mechanism in variety.win_ipc.
+    HAVE_DBUS = False
 
 
 class SafeLogger(logging.Logger):
@@ -88,16 +96,20 @@ def _get_dbus_key():
 DBUS_PATH = "/com/peterlevi/Variety"
 
 
-class VarietyService(dbus.service.Object):
-    def __init__(self, variety_window):
-        self.variety_window = variety_window
-        bus_name = dbus.service.BusName(_get_dbus_key(), bus=dbus.SessionBus())
-        dbus.service.Object.__init__(self, bus_name, DBUS_PATH)
+if HAVE_DBUS:
 
-    @dbus.service.method(dbus_interface=_get_dbus_key(), in_signature="as", out_signature="s")
-    def process_command(self, arguments):
-        result = self.variety_window.process_command(arguments, initial_run=False)
-        return "" if result is None else result
+    class VarietyService(dbus.service.Object):
+        def __init__(self, variety_window):
+            self.variety_window = variety_window
+            bus_name = dbus.service.BusName(_get_dbus_key(), bus=dbus.SessionBus())
+            dbus.service.Object.__init__(self, bus_name, DBUS_PATH)
+
+        @dbus.service.method(
+            dbus_interface=_get_dbus_key(), in_signature="as", out_signature="s"
+        )
+        def process_command(self, arguments):
+            result = self.variety_window.process_command(arguments, initial_run=False)
+            return "" if result is None else result
 
 
 VARIETY_WINDOW = None
@@ -171,7 +183,7 @@ def _set_up_logging(verbose):
 
 
 def main():
-    if os.geteuid() == 0:
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
         print(
             'Variety is not supposed to run as root.\n'
             'You should NEVER run desktop apps as root, unless they are supposed to make '
@@ -197,7 +209,8 @@ def main():
     # Ctrl-C
     signal.signal(signal.SIGINT, _sigint_handler)
     signal.signal(signal.SIGTERM, _sigint_handler)
-    signal.signal(signal.SIGQUIT, _sigint_handler)
+    if hasattr(signal, "SIGQUIT"):
+        signal.signal(signal.SIGQUIT, _sigint_handler)
 
     arguments = sys.argv[1:]
 
@@ -209,9 +222,19 @@ def main():
     Util.makedirs(get_profile_path())
 
     # ensure singleton per profile
-    bus = dbus.SessionBus()
     dbus_key = _get_dbus_key()
-    if bus.request_name(dbus_key) != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
+    if HAVE_DBUS:
+        bus = dbus.SessionBus()
+        already_running = (
+            bus.request_name(dbus_key) != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER
+        )
+    else:
+        from variety import win_ipc
+
+        win_ipc_conn = win_ipc.connect_to_running_instance(dbus_key)
+        already_running = win_ipc_conn is not None
+
+    if already_running:
         if not arguments or (options.profile and len(arguments) <= 2):
             arguments = ["--preferences"]
         safe_print(
@@ -219,8 +242,11 @@ def main():
             "Variety is already running. Sending the command to the running instance.",
             file=sys.stderr,
         )
-        method = bus.get_object(dbus_key, DBUS_PATH).get_dbus_method("process_command")
-        result = method(arguments)
+        if HAVE_DBUS:
+            method = bus.get_object(dbus_key, DBUS_PATH).get_dbus_method("process_command")
+            result = method(arguments)
+        else:
+            result = win_ipc.send_command(win_ipc_conn, arguments)
         if result:
             safe_print(result)
         return
@@ -255,9 +281,11 @@ def main():
     window = VarietyWindow.VarietyWindow()
     global VARIETY_WINDOW
     VARIETY_WINDOW = window
-    service = VarietyService(window)
-
-    bus.call_on_disconnection(window.on_quit)
+    if HAVE_DBUS:
+        service = VarietyService(window)
+        bus.call_on_disconnection(window.on_quit)
+    else:
+        service = win_ipc.WinIPCService(window, dbus_key)
 
     window.start(arguments)
     GObject.timeout_add(2000, _check_quit)

--- a/variety/indicator.py
+++ b/variety/indicator.py
@@ -18,6 +18,7 @@
 
 import logging
 import os
+import sys
 
 from gi.repository import Gtk  # pylint: disable=E0611
 
@@ -318,17 +319,27 @@ class Indicator:
         self.visible = True
 
         def right_click_event(icon, button, time):
-            self.menu.popup(None, None, Gtk.StatusIcon.position_menu, self.status_icon, 0, time)
+            if sys.platform == "win32":
+                # Gtk.StatusIcon.position_menu miscalculates the icon's screen
+                # geometry under the GTK win32 backend (worse with multi-monitor
+                # setups), producing a wildly mispositioned/oversized menu. Popping
+                # up at the pointer instead sidesteps that broken geometry lookup.
+                self.menu.popup(None, None, None, None, button, time)
+            else:
+                self.menu.popup(None, None, Gtk.StatusIcon.position_menu, self.status_icon, 0, time)
 
         def left_click_event(data):
-            self.menu.popup(
-                None,
-                None,
-                Gtk.StatusIcon.position_menu,
-                self.status_icon,
-                0,
-                Gtk.get_current_event_time(),
-            )
+            if sys.platform == "win32":
+                self.menu.popup(None, None, None, None, 0, Gtk.get_current_event_time())
+            else:
+                self.menu.popup(
+                    None,
+                    None,
+                    Gtk.StatusIcon.position_menu,
+                    self.status_icon,
+                    0,
+                    Gtk.get_current_event_time(),
+                )
 
         def on_indicator_scroll_status_icon(status_icon, event):
             window.on_indicator_scroll(None, 1, event.direction)

--- a/variety/plugins/builtin/quotes/FortuneSource.py
+++ b/variety/plugins/builtin/quotes/FortuneSource.py
@@ -20,10 +20,11 @@
 #
 
 import re
+import shutil
 import subprocess
-from locale import gettext as _
 
 from variety.plugins.IQuoteSource import IQuoteSource
+from variety.Util import _
 
 ANSI_ESCAPE_RE = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]", flags=re.IGNORECASE)
 
@@ -45,6 +46,9 @@ class FortuneSource(IQuoteSource):
         return False
 
     def get_random(self):
+        if not shutil.which("fortune"):
+            # not installed on this system (e.g. always the case on Windows)
+            return []
         fortune = subprocess.check_output(["fortune"]).decode().strip()
         fortune = ANSI_ESCAPE_RE.sub("", fortune)
         q = fortune.split("--")

--- a/variety/plugins/builtin/quotes/UrbanDictionarySource.py
+++ b/variety/plugins/builtin/quotes/UrbanDictionarySource.py
@@ -15,10 +15,8 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 ### END LICENSE
 
-from locale import gettext as _
-
 from variety.plugins.IQuoteSource import IQuoteSource
-from variety.Util import Util
+from variety.Util import Util, _
 
 
 class UrbanDictionarySource(IQuoteSource):

--- a/variety/plugins/downloaders/DefaultDownloader.py
+++ b/variety/plugins/downloaders/DefaultDownloader.py
@@ -261,11 +261,11 @@ class DefaultDownloader(Downloader, metaclass=abc.ABCMeta):
         # rename the file to its final intended filename
         try:
             # make sure if an external metadata file was created, to rename it first
-            os.rename(local_filepath_partial + ".metadata.json", local_filepath + ".metadata.json")
+            os.replace(local_filepath_partial + ".metadata.json", local_filepath + ".metadata.json")
         except Exception:
             pass
-        # file rename is an atomic operation, so we should never end up with partial downloads
-        os.rename(local_filepath_partial, local_filepath)
+        # os.replace is an atomic operation, so we should never end up with partial downloads
+        os.replace(local_filepath_partial, local_filepath)
 
         logger.info(lambda: "Download complete")
         return local_filepath

--- a/variety/profile.py
+++ b/variety/profile.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from variety.Util import Util
 
@@ -60,4 +61,12 @@ def get_desktop_file_name():
 
 
 def get_autostart_file_path():
+    if sys.platform == "win32":
+        # Windows has no autostart .desktop convention; a .vbs script dropped in the
+        # Startup folder is run silently (no console window) on every login.
+        name = "Variety.vbs" if is_default_profile() else "Variety-{}.vbs".format(get_profile_id())
+        startup_dir = os.path.join(
+            os.environ["APPDATA"], "Microsoft", "Windows", "Start Menu", "Programs", "Startup"
+        )
+        return os.path.join(startup_dir, name)
     return os.path.join(os.path.expanduser("~/.config/autostart"), get_desktop_file_name())

--- a/variety/win_ipc.py
+++ b/variety/win_ipc.py
@@ -1,0 +1,133 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+"""
+Windows has no D-Bus session bus, so dbus-python isn't available there.
+This module replaces the two things Variety uses D-Bus for on Linux -
+detecting an already-running instance and forwarding it a command - with a
+local loopback TCP socket. It mirrors the shape of the D-Bus calls made in
+variety/__init__.py so the two code paths stay easy to compare.
+
+A loopback socket has no notion of "session" the way the D-Bus session bus
+does, so any local account on a shared machine could otherwise connect and
+send commands. To close that gap, the primary instance writes a random
+per-profile token to a file in the profile folder (readable only by the
+current user's own files by default NTFS permissions) and every client must
+present it before its command is processed.
+"""
+import hashlib
+import json
+import logging
+import os
+import secrets
+import socket
+import threading
+
+logger = logging.getLogger("variety")
+
+HOST = "127.0.0.1"
+
+
+def _port_for_key(dbus_key):
+    # Deterministic per-profile port, so different --profile instances don't collide.
+    # Must be stable across separate processes, so plain hash() (randomized per
+    # process since Python 3.3) would not work here.
+    digest = hashlib.sha256(dbus_key.encode("utf-8")).hexdigest()
+    return 40000 + (int(digest, 16) % 10000)
+
+
+def _token_path():
+    from variety.profile import get_profile_path
+
+    return os.path.join(get_profile_path(), ".win_ipc_token")
+
+
+def _get_or_create_token():
+    path = _token_path()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            token = f.read().strip()
+            if token:
+                return token
+    except OSError:
+        pass
+    token = secrets.token_hex(16)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(token)
+    return token
+
+
+def connect_to_running_instance(dbus_key):
+    """
+    Returns a connected socket if another instance is already listening,
+    otherwise None (meaning this process should become the primary instance).
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(3)
+    try:
+        sock.connect((HOST, _port_for_key(dbus_key)))
+        return sock
+    except OSError:
+        sock.close()
+        return None
+
+
+def send_command(sock, arguments):
+    """Sends arguments to an already-connected running instance and returns its reply."""
+    try:
+        payload = _get_or_create_token().encode("utf-8") + b"\n" + json.dumps(arguments).encode(
+            "utf-8"
+        )
+        sock.sendall(payload)
+        sock.shutdown(socket.SHUT_WR)
+        chunks = []
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode("utf-8")
+    finally:
+        sock.close()
+
+
+class WinIPCService:
+    """
+    Listens for commands from later Variety invocations, playing the same role
+    as the D-Bus VarietyService object does on Linux.
+    """
+
+    def __init__(self, variety_window, dbus_key):
+        self.variety_window = variety_window
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server.bind((HOST, _port_for_key(dbus_key)))
+        self.server.listen(5)
+        threading.Thread(target=self._serve_forever, daemon=True).start()
+
+    def _serve_forever(self):
+        while True:
+            try:
+                conn, _addr = self.server.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn):
+        try:
+            conn.settimeout(5)
+            chunks = []
+            while True:
+                chunk = conn.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            token, _, payload = b"".join(chunks).partition(b"\n")
+            if token.decode("utf-8", errors="replace") != _get_or_create_token():
+                logger.warning("Rejected Windows IPC command with invalid token")
+                return
+            arguments = json.loads(payload.decode("utf-8"))
+            result = self.variety_window.process_command(arguments, initial_run=False)
+            conn.sendall((result or "").encode("utf-8"))
+        except Exception:
+            logger.exception("Error handling command over the Windows IPC socket")
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

Variety now runs as a real, native Windows application - on top of a genuine
Windows GTK3 build provided by [MSYS2](https://www.msys2.org/), not WSL, a
Linux VM, or a rewrite. This is the same codebase, patched at the specific
points where it assumed a Linux desktop (D-Bus, gsettings, libnotify,
AppIndicator, XDG autostart). See [WINDOWS.md](../../blob/windows-support/WINDOWS.md)
for full setup instructions and a complete list of the platform differences.

## What's included

- **Single instance / IPC**: falls back to a local loopback socket
  (`variety/win_ipc.py`, token-authenticated) when `dbus-python` isn't
  available, instead of the D-Bus session bus.
- **Wallpaper**: `SystemParametersInfoW` + registry instead of the
  `set_wallpaper`/`get_wallpaper` shell scripts.
- **Lock screen**: the WinRT `LockScreen` API, invoked via PowerShell's
  built-in WinRT projection support (no new Python dependency).
- **Notifications**: caught gracefully when no notification service is
  listening, instead of raising.
- **Tray icon**: uses the existing `Gtk.StatusIcon` fallback; fixed its popup
  menu positioning, which was badly broken under the GTK win32 backend
  (`Gtk.StatusIcon.position_menu` miscalculates the icon's screen geometry,
  producing a hugely mispositioned/oversized menu - now pops up at the
  pointer instead).
- **Autostart**: a `.vbs` script in the Windows Startup folder instead of an
  XDG `.desktop` file, wired into the existing Preferences autostart
  checkbox.
- Plus a few real, platform-agnostic bugs found along the way: `os.rename`
  doesn't overwrite existing files on Windows (switched to `os.replace` in
  the download paths), an unescaped regex pattern built from a raw
  filesystem path broke on Windows' backslash separators, and two quote
  plugins used `locale.gettext`, which is gone in Python 3.14.

## Test plan

- [x] Ran on Windows 11 via MSYS2's `ucrt64` GTK3/PyGObject/gexiv2 packages
- [x] Verified wallpaper set/get round-trips through the registry correctly
- [x] Verified lock screen image actually changes (checked via Settings ->
      Personalization -> Lock screen)
- [x] Verified the tray menu fix with a deterministic test that emits the
      real `popup-menu` GTK signal on the actual `Indicator` class and
      confirms the resulting menu is correctly sized
- [x] Verified singleton detection/IPC across two separate process
      invocations
- [x] Verified autostart `.vbs` end-to-end (ran it directly, confirmed it
      launches Variety silently after login)
- [x] Not yet tested on Windows 10 (developed/tested on Windows 11 only)

## Known gaps

- The "Fortune" quotes source needs the Linux `fortune` binary; skipped
  cleanly (not an error) when unavailable, which is always the case on
  Windows unless a user separately installs a fortune-mod port.
- `variety-slideshow` isn't packaged for Windows.

Happy to adjust scope/split this up further if that makes it easier to
review, given the maintenance-mode note in the README.