### PR TITLE
Support negative clock_filter offsets ([%HOFFSET-3])

### DIFF
--- a/variety/VarietyWindow.py
+++ b/variety/VarietyWindow.py
@@ -1335,8 +1335,11 @@ class VarietyWindow(Gtk.Window):
         def vrepl(m):
             return str(voffset + int(m.group(1)))
 
-        filter = re.sub(r"\[\%HOFFSET\+(\d+)\]", hrepl, filter)
-        filter = re.sub(r"\[\%VOFFSET\+(\d+)\]", vrepl, filter)
+        # Accept signed offsets ([%HOFFSET+58], [%HOFFSET-3]): anything left
+        # unmatched here reaches time.strftime(), which eats the "%H"/"%V" and
+        # silently corrupts the filter (e.g. "[15OFFSET-3]" at 15:00).
+        filter = re.sub(r"\[\%HOFFSET([+-]\d+)\]", hrepl, filter)
+        filter = re.sub(r"\[\%VOFFSET([+-]\d+)\]", vrepl, filter)
         return filter
 
     def refresh_wallpaper(self):


### PR DESCRIPTION
Fixes #862.

`replace_clock_filter_offsets()` only matched the `+N` form, so a negative offset like `[%HOFFSET-3]` was left unmatched, survived to the `time.strftime()` call, and strftime consumed the `%H` — producing tokens like `[15OFFSET-3]` at 15:00 and failing the magick command with no useful diagnostic.

This accepts a signed offset (`[+-]\d+`); the existing `+N` form behaves exactly as before.

Tested with a filter mixing both forms:

```
-annotate 0x0+[%HOFFSET+58]+[%VOFFSET-3] '%H:%M'
→ -annotate 0x0+158+17 '20:53'   (hoffset=100, voffset=20)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaoUWkWJAzzMnYQbNL4eR2