### PR TITLE
fix: KDE lock screen wallpaper path format

### DIFF
--- a/variety/data/scripts/set_lock_screen
+++ b/variety/data/scripts/set_lock_screen
@@ -20,7 +20,7 @@ detect_desktop() {
 DE=$(detect_desktop)
 
 if [[ "$DE" == "kde" && "${KDE_SESSION_VERSION}" =~ ^[0-9]+$ ]]; then
-    kwriteconfig${KDE_SESSION_VERSION} --file kscreenlockerrc --group Greeter --group Wallpaper --group org.kde.image --group General --key Image "$WP"
+    kwriteconfig${KDE_SESSION_VERSION} --file kscreenlockerrc --group Greeter --group Wallpaper --group org.kde.image --group General --key Image "file://$WP"
 
 elif [ "$DE" == "gnome" ] || [ "$DE" == "unity" ] || [ "$DE" == "budgie" ]; then
     # GNOME Screensaver / Lock screen - thanks to George C. de Araujo for the patch


### PR DESCRIPTION
KDE Plasma 6 (and 5) requires the file:// prefix in the kscreenlockerrc Image key for the org.kde.image plugin. This commit ensures kwriteconfig writes the URI instead of the raw path.

closes #866